### PR TITLE
Merge Changes from GSl realtime runs

### DIFF
--- a/jobs/JRTMA3D_GSIANL
+++ b/jobs/JRTMA3D_GSIANL
@@ -35,9 +35,15 @@ export CNVGRIB=${CNVGRIB:-cnvgrib}
 ##########################################################
 export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
 if [ -d $DATA ] ; then
-   rm  -rf $DATA/*
+   ${ECHO} "$DATA exists, remove its content"
+   if [ "${envir}" == "esrl" ]; then #Jet
+     ${RM} -rf $DATA/output_${PDY}*
+   else
+     ${RM} -rf $DATA/*
+   fi
 else
-   mkdir -p $DATA
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
 fi
 cd $DATA
 
@@ -48,19 +54,24 @@ cd $DATA
 #####################################################
 #setpdy.sh
 #. ${DATA}/PDY
+if [[ "${subcyc}" == "-1" ]]; then #it's hourly run
+  export cycle=${cycle:-t${cyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}.${jobid}"}
+  export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
+else
+  export cycle=${cycle:-t${cyc}${subcyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
+  export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
+fi
 
 export subcyc=${subcyc} #Note: Must define subcyc in upper level script. Can be 00, 15, 30, or 45 /MPondeca, 30Jun2017
                          #only used for rurtma2p5
 
-export cycle=${cycle:-t${cyc}${subcyc}z}
-export PDYHH="${PDY}${cyc}"
 ####################################
 # Determine Job Output Name on System
 ####################################
 export LOG_JJOB=${LOG_JJOB:-$COMROOT/logs/jlogfiles}
 export jlogfile=${jlogfile:-$LOG_JJOB/jlogfile.${jobid}}
-# export pgmout=${pgmout:-"OUTPUT.$$"}
-export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
 if [ ! -d ${LOG_JJOB} ] ; then
    mkdir -p ${LOG_JJOB}
 fi
@@ -80,9 +91,9 @@ export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush/${RUN}}
 export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util/${RUN}}
 
 # date and time for previous and next cycle
+export PDYHH="${PDY}${cyc}"
 export PDYHH_cycm1=$($NDATE -01  "${PDYHH}")
 export PDYHH_cycp1=$($NDATE +01  "${PDYHH}")
-
 export FGS_OPT=${FGS_OPT:-1}
 
 #################################################
@@ -91,7 +102,7 @@ export FGS_OPT=${FGS_OPT:-1}
 export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 
-### Observations Products/Input for the RTMA3D (prepbufr files) 
+### Processed Observations ready to be used by RTMA3D_gsi
 export COMINobsproc_rtma3d=${COMINobsproc_rtma3d:-"${COMIN}/obsprd.${cycle}"}
 if [ ! -d "${COMINobsproc_rtma3d}" ] ; then
   echo " Directory of obs data does NOT exist. Job abort!"
@@ -104,20 +115,18 @@ if [ ! -d "${GESINhrrr_rtma3d}" ] ; then
   echo " Directory of HRRRs fgs data does NOT exist. Job abort!"
   err_exit
 fi
-export COMINHRRRDAS=/gpfs/hps/nco/ops/nwges/para/hrrr/hrrrdasges
+
 ### 3DRTMA GSIANL Products (netcdf)
-#export COMINHRRRDAS=/gpfs/dell2/ptmp/Gang.Zhao/Data/grids/enkf/hrrre_nco_para/2020042117
 export COMOUTgsi_rtma3d=${COMOUTgsi_rtma3d:-"${COMOUT}/gsiprd.${cycle}"}
-export COMINhrrrdas=${COMINhrrrdas:-"${COMINHRRRDAS}"}
+
 if [ ! -d "${COMIN}" ] ; then
    mkdir -p $COMIN
 fi
 if [ ! -d "${COMOUT}" ] ; then
    mkdir -p $COMOUT
 fi
-
 if [ ! -d "${COMOUTgsi_rtma3d}" ] ; then
-   mkdir -p ${COMOUTgsi_rtma3d}
+  ${MKDIR} -p ${COMOUTgsi_rtma3d}
 fi
 
 ###########################################################
@@ -125,10 +134,19 @@ fi
 # The following variables are used in exrtma3d_gsianl.ksh
 #
 ###########################################################
+#   Set the name to the executable
+    export exefile_name_gsi=${exefile_name_gsi:-"rtma3d_gsi"}
+
+if [ "${envir}" != "esrl" ]; then #WCOSS
 #   set the file name of the final analysis file for archive
     if [ ! "${PROD_HEAD}" ] ; then
-      export ANLrtma3d_FNAME="${RUN}.t${cyc}${subcyc}z.wrf_inout.nc"
-      export FGSrtma3d_FNAME="${RUN}.t${cyc}${subcyc}z.firstguess.nc"
+      if [ "${subcyc}" == "-1" ]; then #hourly run
+        tz_str=t${cyc}z
+      else
+        tz_str=t${cyc}${subcyc}z
+      fi
+      export ANLrtma3d_FNAME="${RUN}.${tz_str}.wrf_inout.nc"
+      export FGSrtma3d_FNAME="${RUN}.${tz_str}.firstguess.nc"
     else
       export ANLrtma3d_FNAME="${PROD_HEAD}.wrf_inout.nc"
       export FGSrtma3d_FNAME="${PROD_HEAD}.firstguess.nc"
@@ -140,20 +158,17 @@ fi
         mkdir -p ${DATA_RUNDIR}
     fi
     export DATAHOME=${DATA_RUNDIR}/gsiprd
-#    ${RM} -rf ${DATAHOME}
+    ${RM} -rf ${DATAHOME}
     ${LN} -s  ${DATA}  ${DATAHOME}
 
     export DATAOBSHOME=${DATA_RUNDIR}/obsprd
-#    ${RM} -rf ${DATAOBSHOME}
+    ${RM} -rf ${DATAOBSHOME}
     ${LN} -s  ${COMINobsproc_rtma3d}  ${DATAOBSHOME}
 
     export DATAHOME_BK=${DATA_RUNDIR}/fgsprd
-#    ${RM} -rf ${DATAHOME_BK}
+    ${RM} -rf ${DATAHOME_BK}
     ${LN} -s  ${GESINhrrr_rtma3d}  ${DATAHOME_BK}
-
-
-#   Set the path to the gsi executable
-    export exefile_name_gsi=${exefile_name_gsi:-"rtma3d_gsi"}
+fi
 
 #   Set the path to the GSI static files
     export FIXgsi=${FIXgsi:-"${FIXrtma3d}/gsi"}
@@ -174,7 +189,7 @@ fi
 ######################
 # Execute the script.
 ######################
-${exSCR_GSIANL:-$HOMErtma3d/scripts/ex${RUN}_gsianl_subhr.ksh}
+${exSCR_GSIANL:-$HOMErtma3d/scripts/ex${RUN}_gsianl.ksh}
 export err=$?; err_chk
 
 msg="$0 of $job completed normally"
@@ -182,7 +197,7 @@ postmsg $jlogfile "$msg"
 
 if [ -e "${pgmout}" ] ; then
    cat $pgmout
-   cp -p $pgmout   ${LOG_PGMOUT}
+   cp -p $pgmout ${LOG_PGMOUT}
 fi
 
 ##############################

--- a/jobs/JRTMA3D_OBSPREP_CLOUD
+++ b/jobs/JRTMA3D_OBSPREP_CLOUD
@@ -35,9 +35,15 @@ export CNVGRIB=${CNVGRIB:-cnvgrib}
 ##########################################################
 export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
 if [ -d $DATA ] ; then
-   rm  -rf $DATA/*
+  if [ "${envir}" == "esrl" ]; then #Jet
+    ${RM} -f $DATA/NASALaRCCloudInGSI.bufr
+  else
+    ${ECHO} "$DATA exists, remove its content"
+    ${RM} -rf $DATA/*
+  fi
 else
-   mkdir -p $DATA
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
 fi
 cd $DATA
 
@@ -48,21 +54,24 @@ cd $DATA
 #####################################################
 #setpdy.sh
 #. ${DATA}/PDY
+if [[ "${subcyc}" == "-1" ]]; then #it's hourly run
+  export cycle=${cycle:-t${cyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}.${jobid}"}
+  export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
+else
+  export cycle=${cycle:-t${cyc}${subcyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
+  export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
+fi
 
 export subcyc=${subcyc} #Note: Must define subcyc in upper level script. Can be 00, 15, 30, or 45 /MPondeca, 30Jun2017
                          #only used for rurtma2p5
 
-
-export cycle=${cycle:-t${cyc}${subcyc}z} 
-
-export PDYHH="${PDY}${cyc}"
 ####################################
 # Determine Job Output Name on System
 ####################################
 export LOG_JJOB=${LOG_JJOB:-$COMROOT/logs/jlogfiles}
 export jlogfile=${jlogfile:-$LOG_JJOB/jlogfile.${jobid}}
-# export pgmout=${pgmout:-"OUTPUT.$$"}
-export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
 if [ ! -d ${LOG_JJOB} ] ; then
    mkdir -p ${LOG_JJOB}
 fi
@@ -81,26 +90,13 @@ export PARMrtma3d=${PARMrtma3d:-$HOMErtma3d/parm/${RUN}}
 export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush/${RUN}}
 export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util/${RUN}}
 
-# date and time for previous and next cycle
-export PDYHH_cycm1=$($NDATE -01  "${PDYHH}")
-export PDYHH_cycp1=$($NDATE +01  "${PDYHH}")
-
-export FGS_OPT=${FGS_OPT:-1}
-
 #################################################
 # Set up the INPUT and OUTPUT directories
 #################################################
 export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 
-### Observations Products/Input from RAP
-export COMINrap=${COMINRAP}/rtma_ru.${PDY}
-export COMINhrrr=${COMINHRRR}/hrrr.${PDY}/${domain}
-export COMINlightning=${COMINlightning:-"${COMIN}/lightning.${PDY}"}
-export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
-export COMINradar=${COMINradar:-"${COMIN}/radar.${PDY}"}
-
-### Observations Products/Input for the RTMA3D (prepbufr files) 
+### Processed Observations ready to be used by RTMA3D_gsi
 export COMINobsproc_rtma3d=${COMINobsproc_rtma3d:-"${COMIN}/obsprd.${cycle}"}
 
 if [ ! -d "${COMIN}" ] ; then
@@ -110,7 +106,7 @@ if [ ! -d "${COMOUT}" ] ; then
    mkdir -p $COMOUT
 fi
 if [ ! -d "${COMINobsproc_rtma3d}" ] ; then
-    mkdir -p ${COMINobsproc_rtma3d}
+  ${MKDIR} -p $COMINobsproc_rtma3d
 fi
 
 ###########################################################
@@ -118,7 +114,6 @@ fi
 # The following variables are used in exrtma3d_obsprep_cloud.ksh
 #
 ###########################################################
-
 #   Set the name to the executable
     export exefile_name_cloud=${exefile_name_cloud:-"rtma3d_process_cloud"}
 
@@ -131,13 +126,16 @@ fi
     export PARMwrf=${PARMwrf:-"${PARMrtma3d}/wrf"}
 
     export OBS_USELIST=${OBS_USELIST:-"${FIXrtma3d}/gsi"}
+    export SFCOBS_USELIST=${SFCOBS_USELIST:-"${FIXrtma3d}/gsi"}
+    export AIRCRAFT_REJECT=${AIRCRAFT_REJECT:-"${FIXrtma3d}/gsi"}
+    export SFCOBS_PROVIDER=${SFCOBS_PROVIDER:-"${FIXrtma3d}/gsi"}
 
 ##########################################################
 
 ######################
 # Execute the script.
 ######################
-${exSCR_OBSPREP_CLOUD:-$HOMErtma3d/scripts/${RUN}/ex${RUN}_cloud.ksh}
+${exSCR_OBSPREP_CLOUD:-$HOMErtma3d/scripts/ex${NET}_obsprep_cloud.ksh}
 export err=$?; err_chk
 
 msg="$0 of $job completed normally"
@@ -145,7 +143,7 @@ postmsg $jlogfile "$msg"
 
 if [ -e "${pgmout}" ] ; then
    cat $pgmout
-   cp -p $pgmout   ${LOG_PGMOUT}
+   cp -p $pgmout ${LOG_PGMOUT}
 fi
 
 ##############################

--- a/jobs/JRTMA3D_OBSPREP_LGHTN
+++ b/jobs/JRTMA3D_OBSPREP_LGHTN
@@ -35,9 +35,15 @@ export CNVGRIB=${CNVGRIB:-cnvgrib}
 ##########################################################
 export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
 if [ -d $DATA ] ; then
-   rm  -rf $DATA/*
+  if [ "${envir}" == "esrl" ]; then #Jet
+    ${RM} -f $DATA/LightningInGSI.bufr
+  else
+    ${ECHO} "$DATA exists, remove its content"
+    ${RM} -rf $DATA/*
+  fi
 else
-   mkdir -p $DATA
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
 fi
 cd $DATA
 
@@ -48,19 +54,24 @@ cd $DATA
 #####################################################
 #setpdy.sh
 #. ${DATA}/PDY
+if [[ "${subcyc}" == "-1" ]]; then #it's hourly run
+  export cycle=${cycle:-t${cyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}.${jobid}"}
+  export COMINlightning=${COMINlightning:-"${COMIN}/lightning.${PDY}"}
+else
+  export cycle=${cycle:-t${cyc}${subcyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
+  export COMINlightning=${COMINlightning:-"${COMIN}/lightning.${PDY}"}
+fi
 
 export subcyc=${subcyc} #Note: Must define subcyc in upper level script. Can be 00, 15, 30, or 45 /MPondeca, 30Jun2017
                          #only used for rurtma2p5
 
-export cycle=${cycle:-t${cyc}${subcyc}z}
-export PDYHH="${PDY}${cyc}"
 ####################################
 # Determine Job Output Name on System
 ####################################
 export LOG_JJOB=${LOG_JJOB:-$COMROOT/logs/jlogfiles}
 export jlogfile=${jlogfile:-$LOG_JJOB/jlogfile.${jobid}}
-# export pgmout=${pgmout:-"OUTPUT.$$"}
-export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
 if [ ! -d ${LOG_JJOB} ] ; then
    mkdir -p ${LOG_JJOB}
 fi
@@ -79,30 +90,14 @@ export PARMrtma3d=${PARMrtma3d:-$HOMErtma3d/parm/${RUN}}
 export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush/${RUN}}
 export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util/${RUN}}
 
-# date and time for previous and next cycle
-export PDYHH_cycm1=$($NDATE -01  "${PDYHH}")
-export PDYHH_cycp1=$($NDATE +01  "${PDYHH}")
-
-export FGS_OPT=${FGS_OPT:-1}
-
 #################################################
 # Set up the INPUT and OUTPUT directories
 #################################################
 export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 
-### Observations Products/Input from RAP
-export COMINrap=${COMINRAP}/rtma_ru.${PDY}
-export COMINhrrr=${COMINHRRR}/hrrr.${PDY}/${domain}
-export COMINlightning=${COMINlightning:-"${COMIN}/lightning.${PDY}"}
-export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
-export COMINradar=${COMINradar:-"${COMIN}/radar.${PDY}"}
-
-### Observations Products/Input for the RTMA3D (prepbufr files) 
+### Processed Observations ready to be used by RTMA3D_gsi
 export COMINobsproc_rtma3d=${COMINobsproc_rtma3d:-"${COMIN}/obsprd.${cycle}"}
-
-### Firstguess Products/Input for the RTMA3D (prepbufr files) 
-export GESINhrrr_rtma3d=${GESINhrrr_rtma3d:-"${COMIN}/fgsprd.${cycle}"}
 
 if [ ! -d "${COMIN}" ] ; then
    mkdir -p $COMIN
@@ -111,9 +106,7 @@ if [ ! -d "${COMOUT}" ] ; then
    mkdir -p $COMOUT
 fi
 if [ ! -d "${COMINobsproc_rtma3d}" ] ; then
-# echo " Directory of obs data does NOT exist. Job abort!"
-# err_exit
-  mkdir -p $COMINobsproc_rtma3d
+  ${MKDIR} -p $COMINobsproc_rtma3d
 fi
 
 ###########################################################
@@ -121,26 +114,28 @@ fi
 # The following variables are used in exrtma3d_obsprep_lghtn.ksh
 #
 ###########################################################
-
 #   Set the name to the executable
     export exefile_name_lightning=${exefile_name_lightning:-"rtma3d_process_lightning"}
 
 #   Set the path to the GSI static files
-    export FIXgsi=${FIX_GSI:-"${FIXrtma3d}/gsi"}
-    export FIXcrtm=${FIX_CRTM:-"${FIXrtma3d}/crtm"}
+    export FIXgsi=${FIXgsi:-"${FIXrtma3d}/gsi"}
+    export FIXcrtm=${FIXcrtm:-"${FIXrtma3d}/crtm"}
     export FIXwps=${FIXwps:-"${FIXrtma3d}/wps"}
 
     export PARMupp=${PARMupp:-"${PARMrtma3d}/upp"}
     export PARMwrf=${PARMwrf:-"${PARMrtma3d}/wrf"}
 
     export OBS_USELIST=${OBS_USELIST:-"${FIXrtma3d}/gsi"}
+    export SFCOBS_USELIST=${SFCOBS_USELIST:-"${FIXrtma3d}/gsi"}
+    export AIRCRAFT_REJECT=${AIRCRAFT_REJECT:-"${FIXrtma3d}/gsi"}
+    export SFCOBS_PROVIDER=${SFCOBS_PROVIDER:-"${FIXrtma3d}/gsi"}
 
 ##########################################################
 
 ######################
 # Execute the script.
 ######################
-${exSCR_OBSPREP_LGHTN:-$HOMErtma3d/scripts/ex${RUN}_obsprep_lghtn.ksh}
+${exSCR_OBSPREP_LGHTN:-$HOMErtma3d/scripts/ex${NET}_obsprep_lghtn.ksh}
 export err=$?; err_chk
 
 msg="$0 of $job completed normally"
@@ -148,7 +143,7 @@ postmsg $jlogfile "$msg"
 
 if [ -e "${pgmout}" ] ; then
    cat $pgmout
-   cp -p $pgmout   ${LOG_PGMOUT}
+   cp -p $pgmout ${LOG_PGMOUT}
 fi
 
 ##############################

--- a/jobs/JRTMA3D_OBSPREP_RADAR
+++ b/jobs/JRTMA3D_OBSPREP_RADAR
@@ -35,9 +35,15 @@ export CNVGRIB=${CNVGRIB:-cnvgrib}
 ##########################################################
 export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
 if [ -d $DATA ] ; then
-   rm  -rf $DATA/*
+  if [ "${envir}" == "esrl" ]; then #Jet
+    ${RM} -f $DATA/NSSLRefInGSI.bufr
+  else
+    ${ECHO} "$DATA exists, remove its content"
+    ${RM} -rf $DATA/*
+  fi
 else
-   mkdir -p $DATA
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
 fi
 cd $DATA
 
@@ -46,20 +52,26 @@ cd $DATA
 #    setpdy.sh needs the variables 
 #    $PDY and $cyc already defined in advance
 #####################################################
-export cycle=${cycle:-t${cyc}${subcyc}z}
 #setpdy.sh
 #. ${DATA}/PDY
+if [[ "${subcyc}" == "-1" ]]; then #it's hourly run
+  export cycle=${cycle:-t${cyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}.${jobid}"}
+  export COMINradar=${COMINradar:-"${COMINRADAR}/radar.${PDY}"}
+else
+  export cycle=${cycle:-t${cyc}${subcyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
+  export COMINradar=${COMINradar:-"${COMINRADAR}/radar.${PDY}${cyc}"}
+fi
 
 export subcyc=${subcyc} #Note: Must define subcyc in upper level script. Can be 00, 15, 30, or 45 /MPondeca, 30Jun2017
                          #only used for rurtma2p5
-export PDYHH="${PDY}${cyc}"
+
 ####################################
 # Determine Job Output Name on System
 ####################################
 export LOG_JJOB=${LOG_JJOB:-$COMROOT/logs/jlogfiles}
 export jlogfile=${jlogfile:-$LOG_JJOB/jlogfile.${jobid}}
-# export pgmout=${pgmout:-"OUTPUT.$$"}
-export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
 if [ ! -d ${LOG_JJOB} ] ; then
    mkdir -p ${LOG_JJOB}
 fi
@@ -78,30 +90,14 @@ export PARMrtma3d=${PARMrtma3d:-$HOMErtma3d/parm/${RUN}}
 export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush/${RUN}}
 export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util/${RUN}}
 
-# date and time for previous and next cycle
-export PDYHH_cycm1=$($NDATE -01  "${PDYHH}")
-export PDYHH_cycp1=$($NDATE +01  "${PDYHH}")
-
-export FGS_OPT=${FGS_OPT:-1}
-
 #################################################
 # Set up the INPUT and OUTPUT directories
 #################################################
 export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}}
 
-### Observations Products/Input from RAP
-export COMINrap=${COMINrap:-"${COMIN}/rap.${PDY}"}
-export COMINhrrr=${COMINhrrr:-"${COMIN}/hrrr.${PDY}/conus"}
-export COMINlightning=${COMINlightning:-"${COMIN}/lightning.${PDY}"}
-export COMINmosaic=${COMINmosaic:-"${COMIN}/radar.${PDY}"}
-export COMINradar=${COMINradar:-"${COMINRADAR}"}
-
-### Observations Products/Input for the RTMA3D (prepbufr files) 
+### Processed Observations ready to be used by RTMA3D_gsi
 export COMINobsproc_rtma3d=${COMINobsproc_rtma3d:-"${COMIN}/obsprd.${cycle}"}
-
-### Firstguess Products/Input for the RTMA3D (prepbufr files) 
-export GESINhrrr_rtma3d=${GESINhrrr_rtma3d:-"${COMIN}/fgsprd.${cycle}"}
 
 if [ ! -d "${COMIN}" ] ; then
    mkdir -p $COMIN
@@ -110,9 +106,7 @@ if [ ! -d "${COMOUT}" ] ; then
    mkdir -p $COMOUT
 fi
 if [ ! -d "${COMINobsproc_rtma3d}" ] ; then
-# echo " Directory of obs data does NOT exist. Job abort!"
-# err_exit
-  mkdir -p $COMINobsproc_rtma3d
+  ${MKDIR} -p $COMINobsproc_rtma3d
 fi
 
 ###########################################################
@@ -120,7 +114,6 @@ fi
 # The following variables are used in exrtma3d_obsprep_radar.ksh
 #
 ###########################################################
-
 #   Set the name to the executable
     export exefile_name_radar=${exefile_name_radar:-"rtma3d_process_mosaic"}
 
@@ -142,7 +135,7 @@ fi
 ######################
 # Execute the script.
 ######################
-${exSCR_OBSPREP_RADAR:-$HOMErtma3d/scripts/ex${RUN}_obsprep_radar.ksh}
+${exSCR_OBSPREP_RADAR:-$HOMErtma3d/scripts/ex${NET}_obsprep_radar.ksh}
 export err=$?; err_chk
 
 msg="$0 of $job completed normally"
@@ -150,7 +143,7 @@ postmsg $jlogfile "$msg"
 
 if [ -e "${pgmout}" ] ; then
    cat $pgmout
-   cp -p $pgmout   ${LOG_PGMOUT}
+   cp -p $pgmout ${LOG_PGMOUT}
 fi
 
 ##############################

--- a/jobs/JRTMA3D_POST
+++ b/jobs/JRTMA3D_POST
@@ -35,9 +35,15 @@ export CNVGRIB=${CNVGRIB:-cnvgrib}
 ##########################################################
 export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
 if [ -d $DATA ] ; then
-   rm  -rf $DATA/*
+   ${ECHO} "$DATA exists, remove its content"
+   if [ "${envir}" == "esrl" ]; then #Jet
+     ${RM} -rf $DATA/wrf*.grib2
+   else
+     ${RM} -rf $DATA/*
+   fi
 else
-   mkdir -p $DATA
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
 fi
 cd $DATA
 
@@ -48,19 +54,21 @@ cd $DATA
 #####################################################
 #setpdy.sh
 #. ${DATA}/PDY
+if [[ "${subcyc}" == "-1" ]]; then #it's hourly run
+  export cycle=${cycle:-t${cyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}.${jobid}"}
+else
+  export cycle=${cycle:-t${cyc}${subcyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
+fi
 
 export subcyc=${subcyc} #Note: Must define subcyc in upper level script. Can be 00, 15, 30, or 45 /MPondeca, 30Jun2017
                          #only used for rurtma2p5
-
-export cycle=${cycle:-t${cyc}${subcyc}z}
-export PDYHH="${PDY}${cyc}"
 ####################################
 # Determine Job Output Name on System
 ####################################
 export LOG_JJOB=${LOG_JJOB:-$COMROOT/logs/jlogfiles}
 export jlogfile=${jlogfile:-$LOG_JJOB/jlogfile.${jobid}}
-# export pgmout=${pgmout:-"OUTPUT.$$"}
-export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}${subcyc}.${jobid}"}
 if [ ! -d ${LOG_JJOB} ] ; then
    mkdir -p ${LOG_JJOB}
 fi
@@ -69,7 +77,7 @@ if [ ! -d ${LOG_PGMOUT} ] ; then
 fi
 
 # specify the file head for the file names of the archived data files
-export PROD_HEAD=${PROD_HEAD:-"${RUN}.t${cyc}${subcyc}z"}
+export PROD_HEAD=${PROD_HEAD:-"${RUN}.${cycle}"}
 
 # Specify Execution Areas
 export HOMErtma3d=${HOMErtma3d:-$NWROOT/rtma.${rtma_ver}}
@@ -80,6 +88,7 @@ export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush/${RUN}}
 export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util/${RUN}}
 
 # date and time for previous and next cycle
+export PDYHH="${PDY}${cyc}"
 export PDYHH_cycm1=$($NDATE -01  "${PDYHH}")
 export PDYHH_cycp1=$($NDATE +01  "${PDYHH}")
 export FGS_OPT=${FGS_OPT:-1}
@@ -111,7 +120,6 @@ fi
 if [ ! -d "${COMOUT}" ] ; then
    mkdir -p $COMOUT
 fi
-
 if [ ! -d "${COMOUTpost_rtma3d}" ] ; then
    mkdir -p ${COMOUTpost_rtma3d}
 fi
@@ -122,33 +130,35 @@ fi
 #
 ###########################################################
 #   set the file name of the final analysis file for archive
-    if [ ! "${PROD_HEAD}" ] ; then
-      export ANLrtma3d_FNAME="${RUN}.t${cyc}${subcyc}z.wrf_inout.nc"
-      export FGSrtma3d_FNAME="${RUN}.t${cyc}${subcyc}z.firstguess.nc"
-    else
-      export ANLrtma3d_FNAME="${PROD_HEAD}.wrf_inout.nc"
-      export FGSrtma3d_FNAME="${PROD_HEAD}.firstguess.nc"
-    fi
+if [ ! "${PROD_HEAD}" ] ; then
+  export ANLrtma3d_FNAME="${RUN}.${cycle}.wrf_inout.nc"
+  export FGSrtma3d_FNAME="${RUN}.${cycle}.firstguess.nc"
+else
+  export ANLrtma3d_FNAME="${PROD_HEAD}.wrf_inout.nc"
+  export FGSrtma3d_FNAME="${PROD_HEAD}.firstguess.nc"
+fi
 
 #   Set the name to the post executable
-    export exefile_name_post=${exefile_name_post:-"rtma3d_wrfpost"}
+export exefile_name_post=${exefile_name_post:-"rtma3d_post"}
 
 #   Set the path to the fix/ and parm/ files
-    export FIXgsi=${FIXgsi:-"${FIXrtma3d}/gsi"}
-    export FIXcrtm=${FIXcrtm:-"${FIXrtma3d}/crtm"}
-    export FIXwps=${FIXwps:-"${FIXrtma3d}/wps"}
+export FIXgsi=${FIXgsi:-"${FIXrtma3d}/gsi"}
+export FIXcrtm=${FIXcrtm:-"${FIXrtma3d}/crtm"}
+export FIXwps=${FIXwps:-"${FIXrtma3d}/wps"}
+export FIXupp=${FIXupp:-"${FIXrtma3d}/upp"}
 
-    export PARMupp=${PARMupp:-"${PARMrtma3d}/upp"}
-    export PARMwrf=${PARMwrf:-"${PARMrtma3d}/wrf"}
+export PARMupp=${PARMupp:-"${PARMrtma3d}/upp"}
+export PARMwrf=${PARMwrf:-"${PARMrtma3d}/wrf"}
 
-    export OBS_USELIST=${OBS_USELIST:-"${FIXrtma3d}/gsi"}
-    export SFCOBS_USELIST=${SFCOBS_USELIST:-"${FIXrtma3d}/gsi"}
-    export AIRCRAFT_REJECT=${AIRCRAFT_REJECT:-"${FIXrtma3d}/gsi"}
-    export SFCOBS_PROVIDER=${SFCOBS_PROVIDER:-"${FIXrtma3d}/gsi"}
+export OBS_USELIST=${OBS_USELIST:-"${FIXrtma3d}/gsi"}
+export SFCOBS_USELIST=${SFCOBS_USELIST:-"${FIXrtma3d}/gsi"}
+export AIRCRAFT_REJECT=${AIRCRAFT_REJECT:-"${FIXrtma3d}/gsi"}
+export SFCOBS_PROVIDER=${SFCOBS_PROVIDER:-"${FIXrtma3d}/gsi"}
 
 ##########################################################
+if [ "${envir}" != "esrl" ]; then #WCOSS
+#   Link the path to the working UPP directory #tmp.debug do we need this?
 
-#   Link the path to the working UPP directory
     export DATA_RUNDIR=${DATA_RUNDIR:-"${DATAROOT}/${envir}/${RUN}.${PDY}${cyc}${subcyc}"}
     if [ ! -d "${DATA_RUNDIR}" ] ; then
         mkdir -p ${DATA_RUNDIR}
@@ -156,6 +166,7 @@ fi
     export DATA_POST=${DATA_POST:-"${DATA_RUNDIR}/postprd"}
     ${RM} -rf ${DATA_POST}
     ${LN} -s  ${DATA}  ${DATA_POST}
+fi
 
 ######################
 # Execute the script.
@@ -168,7 +179,7 @@ postmsg $jlogfile "$msg"
 
 if [ -e "${pgmout}" ] ; then
    cat $pgmout
-   cp -p $pgmout   ${LOG_PGMOUT}
+   cp -p $pgmout ${LOG_PGMOUT}
 fi
 
 ##############################

--- a/jobs/JRTMA3D_UPDATEVARS
+++ b/jobs/JRTMA3D_UPDATEVARS
@@ -33,19 +33,19 @@ export CNVGRIB=${CNVGRIB:-cnvgrib}
 ##########################################################
 # make temp/running directories
 ##########################################################
-#export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
-#if [ -d $DATA ] ; then
-#   ${ECHO} "$DATA exists, remove its content"
-#   if [ "${envir}" == "esrl" ]; then #Jet
-#     ${RM} -rf $DATA/namelist.output #logic keeper
-#   else
-#     ${RM} -rf $DATA/*
-#   fi
-#else
-#   ${ECHO} "$DATA does not exist, create it"
-#   ${MKDIR} -p $DATA
-#fi
-#cd $DATA
+export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
+if [ -d $DATA ] ; then
+   ${ECHO} "$DATA exists, remove its content"
+   if [ "${envir}" == "esrl" ]; then #Jet
+     ${RM} -rf $DATA/namelist.output #logic keeper
+   else
+     ${RM} -rf $DATA/*
+   fi
+else
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
+fi
+cd $DATA
 
 #####################################################
 # Run setpdy and initialize PDY variables
@@ -135,9 +135,8 @@ fi
 #
 ###########################################################
 #   Set the name to the executable
-    export exefile_name_updatevars=${exefile_name_updatevars_wrf:-"rtma3d_updatevars_wrf"}
+    export exefile_name_updatevars=${exefile_name_updatevars:-"rtma3d_updatevars"}
     export exefile_name_update_ncfields=${exefile_name_updatevars_ncfields:-"rtma3d_updatevars_ncfields"}
-    export exefile_name_updatevars_ndown=${exefile_name_updatevars_ndown:-"rtma3d_updatevars_ndown"}
 
 if [ "${envir}" != "esrl" ]; then #WCOSS
 #   set the file name of the final analysis file for archive
@@ -160,15 +159,15 @@ if [ "${envir}" != "esrl" ]; then #WCOSS
         mkdir -p ${DATA_RUNDIR}
     fi
     export DATAHOME=${DATA_RUNDIR}/gsiprd
-#    ${RM} -rf ${DATAHOME}
+    ${RM} -rf ${DATAHOME}
     ${LN} -s  ${DATA}  ${DATAHOME}
 
     export DATAOBSHOME=${DATA_RUNDIR}/obsprd
-#    ${RM} -rf ${DATAOBSHOME}
+    ${RM} -rf ${DATAOBSHOME}
     ${LN} -s  ${COMINobsproc_rtma3d}  ${DATAOBSHOME}
 
     export DATAHOME_BK=${DATA_RUNDIR}/fgsprd
-#    ${RM} -rf ${DATAHOME_BK}
+    ${RM} -rf ${DATAHOME_BK}
     ${LN} -s  ${GESINhrrr_rtma3d}  ${DATAHOME_BK}
 fi
 

--- a/jobs/launch.ksh
+++ b/jobs/launch.ksh
@@ -44,39 +44,12 @@ if [ "${machine}" = "theia" ] ; then
   esac
   module list
 elif [ "${machine}" = "jet" ] ; then
+  [[ "$-" == *"x"* ]] && set +x && prev_x="YES"
   . /etc/profile
   . /etc/profile.d/modules.sh >/dev/null # Module Support
-  module purge
-# loading modules used when building the code
-  case "$COMMAND" in
-    *POST*)
-      modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.post.${machine}"}
-      moduledir=`dirname $(readlink -f ${modulefile_build})`
-      module use ${moduledir}
-      module load modulefile.build.post.${machine}
-      ;;
-    *GSIANL*)
-      modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.gsi.${machine}"}
-      source $modulefile_build
-      ;;
-    *)
-#     modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.gsi.PreInstalledLibs.${machine}"}
-      modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.gsi.${machine}"}
-      source $modulefile_build
-      ;;
-  esac
-# loading modules for running
-  modulefile_run=${modulefile_run:-"${MODULEFILES}/${machine}/run/modulefile.run.${machine}"}
-  source ${modulefile_run}
-# loading modules for specific task
-  case "$COMMAND" in
-    *VERIF*)
-      module load met/8.0
-      ;;
-    *)
-      ;;
-  esac
+  source ${modulefile_jet}
   module list
+  [[ "${prev_x}" == "YES"  ]] && set -x
 
 elif [ "${machine}" = "dell" ] ; then
   . /etc/profile
@@ -125,7 +98,7 @@ fi
 if [ "${machine}" = "theia" ] ; then    ### PBS job Scheduler
 
   case ${SCHEDULER} in
-    SLURM|slum)                                       # SLURM
+    SLURM|slurm)                                       # SLURM
       module load rocoto/1.3.0-RC5
       module load slurm/18.08
 
@@ -168,39 +141,14 @@ EOF
   export jobid=${jobid:-"${job}.${jid}"}
   echo " number of cores : $np for job $job with id as $jobid "
 
-elif [ "${machine}" = "jet" ] ;  then    ### PBS job Scheduler
-
+#----------- for Jet realtime run ------------------------------------------------------------------
+elif [ "${machine}" = "jet" ] ;  then
   case ${SCHEDULER} in
-    SLURM|slum)                                       # SLURM
-      module load rocoto/1.3.0-RC5
-      module load slurm/18.08.7p1
-
-      export PBS_JOBID=${SLURM_JOB_ID}
-      export PBS_JOBNAME=${SLURM_JOB_NAME}
-      export PBS_NP=${SLURM_NTASKS}
-      export PBS_O_DIR=${SLURM_SUBMIT_DIR}
-
-      cd ${SLURM_SUBMIT_DIR}
-      if [ ! -d ${LOG_DIR}/nodefiles ] ; then
-        mkdir -p ${LOG_DIR}/nodefiles
-      fi
-      slurm_hfile=${LOG_DIR}/nodefiles/hostfile.${SLURM_JOB_NAME}.${SLURM_JOB_ID}
-      scontrol show hostname $SLURM_NODELSIT > ${slurm_hfile}
-      export PBS_NODEFILE=${LOG_DIR}/nodefiles/pbs_nodefile.${SLURM_JOB_NAME}.${SLURM_JOB_ID}
-      if [ -f ${PBS_NODEFILE} ] ; then
-        rm -f ${PBS_NODEFILE}
-      fi
-      i=0
-      imax=${SLURM_NTASKS}
-      while [[ $i -lt ${SLURM_NTASKS} ]]
-      do
-        cat >> ${PBS_NODEFILE} << EOF
-node$i
-EOF
-        (( i += 1 ))
-      done
-      np=`cat $PBS_NODEFILE | wc -l`
-      echo "Launch.sh: ${SLURM_JOB_NAME} np=$np (in $PBS_NODEFILE)"
+    SLURM|slurm)
+      [[ "$-" == *"x"* ]] && set +x && prev_x="YES"
+      module load rocoto
+      [[ "${prev_x}" == "YES"  ]] && set -x
+      export np=${SLURM_NTASKS}
       export MPIRUN="srun"
       ;;
     *)
@@ -208,12 +156,41 @@ EOF
       exit 1
       ;;
   esac
-  export job=${job:-"${PBS_JOBNAME}"}    # job is defined as job name
-  export jid=`echo ${PBS_JOBID} | cut -f1 -d.`  # removal of tailing sub-server string
-# export jid=`echo ${PBS_JOBID} | awk -F'.' '{print $1}'`
+  export job=${job:-"${SLURM_JOB_NAME}"}    # job is defined as job name
+  export jid=`echo ${SLURM_JOB_ID} | cut -f1 -d.`  # removal of tailing sub-server string
   export jobid=${jobid:-"${job}.${jid}"}
   echo " number of cores : $np for job $job with id as $jobid "
+  export __ms_shell="ksh" ##NCEP err_exit need this
 
+  if [ -z "${rundir_task}" ]; then
+    ${ECHO} "Fatal error: \$rundir_task is not defined"
+    exit 1
+  fi
+  export DATA=${rundir_task} #Jet experimental run will not append ${jid} to rundir
+  if [[ "${envir}"=="esrl"  ]]; then # Jet experimental runs
+    export EXECrtma3d=${EXECrtma3d:-$HOMErtma3d/exec}
+    export FIXrtma3d=${FIXrtma3d:-$HOMErtma3d/fix}
+    export PARMrtma3d=${PARMrtma3d:-$HOMErtma3d/parm}
+    export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush}
+    export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util}
+    export LOG_PGMOUT="${COMROOT}/stdout/${PDY}"
+    export pgmout="output_${PDY}.${job}"
+    export LOG_JJOB="${COMROOT}/log/${PDY}"
+    [ ! -d ${COMROOT}/loghistory ] && ${MKDIR} -p ${COMROOT}/loghistory
+    export COMINobsproc_rtma3d="${COMROOT}/ptmp/${PDY}/obs"
+    export COMOUTgsi_rtma3d="${COMROOT}/ptmp/${PDY}/gsi"
+    export COMOUTwrf_rtma3d="${COMROOT}/ptmp/${PDY}/wrf"
+    export COMOUTpost_rtma3d="${COMROOT}/ptmp/${PDY}/post"
+
+    # the following is just to pass dir check for Jet esrl runs
+    export GESINhrrr_rtma3d="/tmp" 
+    export COMIN="/tmp"
+    export COMOUT="/tmp"
+    export COMINrap="/tmp"
+    export COMINhrrr="/tmp"
+  fi
+
+#----------- for Dell ------------------------------------------------------------------------
 elif [ "${machine}" = "dell" ] ; then  ### LSB scheduler
 
   case ${SCHEDULER} in
@@ -234,6 +211,14 @@ elif [ "${machine}" = "dell" ] ; then  ### LSB scheduler
   export jid=`echo ${LSB_JOBID} | cut -f1 -d.`  # removal of tailing sub-server string
   export jobid=${jobid:-"${job}.${jid}"}
   echo " number of cores : $np for job $job with id as $jobid "
+  ############################################################
+  # Notice: the following line is to                         #
+  #            name the running directory with job name.     #
+  #                              (not used for NCO.)         #
+  ############################################################
+  if [ "${rundir_task}" ]; then
+      export DATA=${rundir_task}.${jid}
+  fi
 
  
 else
@@ -241,17 +226,9 @@ else
   export job=${job:-"${outid}.o$$"}
   export jobid=${jobid:-"${outid}.o$$"}
   export jid=$$
-#  export MPIRUN=${MPIRUN:-"mpirun"}
+  export MPIRUN=${MPIRUN:-"mpirun"}
 
 fi
 
-############################################################
-# Notice: the following line is to                         #
-#            name the running directory with job name.     #
-#                              (not used for NCO.)         #
-############################################################
-if [ "${rundir_task}" ]; then
-  export DATA=${rundir_task}.${jid}
-fi
 
 $COMMAND

--- a/scripts/exrtma3d_gsianl.ksh
+++ b/scripts/exrtma3d_gsianl.ksh
@@ -440,13 +440,14 @@ if [ "${envir}" == "esrl" ];  then ##GSI on Jet needs special treatment
 else
   ${MPIRUN} ${pgm} < gsiparm.anl > ${pgmout} 2>errfile
 fi
+export err=$?;
 ##save some information for possible debugging before err_chk
 ${CAT} fort.* >   fits_${cycle_str}.txt
 #${LS} -l > GSI_workdir_list
 ${CAT} errfile >> ${pgmout}
 #${MV} ${pgmout} ${pgmout}.var
 ${CP} -p fits_${cycle_str}.txt ${COMOUTgsi_rtma3d}
-export err=$?; err_chk
+err_chk
 
 # Loop over first and last outer loops to generate innovation
 # diagnostic files for indicated observation types (groups)
@@ -520,11 +521,12 @@ EOF
   else
     ${MPIRUN} ${pgm} < gsiparm.anl >> ${pgmout} 2>errfile
   fi
+  export err=$?;
   #${LS} -l > GSI_workdir_list
   ${CAT} errfile >> ${pgmout}
   ${ECHO} -e "\n\n -- End of second GSI --\n" >> ${pgmout}
   #${CP} -p ${pgmout} ${COMOUTgsi_rtma3d}/${pgmout}.cloudana #this output should be in $LLOG_PGMOUT
-  export err=$?; err_chk
+  err_chk
 
 fi ###### second GSI run
 

--- a/scripts/exrtma3d_gsianl.ksh
+++ b/scripts/exrtma3d_gsianl.ksh
@@ -1,258 +1,253 @@
-#!/bin/ksh
+#!/bin/ksh --login
+set -x
+check_if_defined() { #usage: check_if_defined "var1_name" "var2_name" ...
+  for str in "$@"; do
+    eval "path=\${$str}"
+    if [ -z "${path}" ]; then
+      ${ECHO} "ERROR: \$${str} is not defined"; exit 1
+    fi
+  done
+}
+check_dirs_exist() { #usage: check_dirs_exist "var1_name" "var2_name" ...
+  for str in "$@"; do
+    eval "path=\${$str}"
+    if [ ! -d ${path} ]; then
+      ${ECHO} "ERROR: ${path}/ does not exist"; exit 1
+    fi
+  done
+}
 
-set -x 
-
-#-- This script is goint to run GSI analysis (3DVar and Cloud analysis) in one-step
-#
-echo " This script is goint to run GSI analysis (3DVar and Cloud analysis) in one-step"
-#-- Testing the status of some important variables. --#
-# Make sure DATAHOME is defined and exists
-if [ ! "${DATAHOME}" ]; then
-  ${ECHO} "ERROR: \$DATAHOME is not defined!"
-  exit 1
-fi
-if [ ! -d "${DATAHOME}" ]; then
-  ${ECHO} "ERROR: DATAHOME directory '${DATAHOME}' does not exist!"
-  exit 1
-fi
-# Make sure DATAOBSHOME is defined and exists
-if [ ! "${DATAOBSHOME}" ]; then
-  ${ECHO} "ERROR: \$DATAOBSHOME is not defined!"
-  exit 1
-fi
-if [ ! -d "${DATAOBSHOME}" ]; then
-  ${ECHO} "ERROR: DATAOBSHOME directory '${DATAOBSHOME}' does not exist!"
-  exit 1
-fi
-# Make sure DATAHOME_BK is defined and exists
-if [ ! "${DATAHOME_BK}" ]; then
-  ${ECHO} "ERROR: \$DATAHOME_BK is not defined!"
-  exit 1
-fi
-if [ ! -d "${DATAHOME_BK}" ]; then
-  ${ECHO} "ERROR: DATAHOME_BK directory '${DATAHOME_BK}' does not exist!"
-  exit 1
-fi
-
-
-# test the existence of script genating namelist file for gsi
-if [ ! -f ${PARMgsi}/gsiparm.anl.sh ] ; then
-  ${ECHO} "ERROR: ${PARMgsi}/gsiparm.anl.sh does not exist!"
-   exit 1
-fi
-
-if [  "${DATA_GSIANL}" ]; then
-  ${RM} -rf ${DATA_GSIANL}
-  ${LN} -sf ${DATA} ${DATA_GSIANL}
-fi
-
-
-
-
-#  NCEPSNOW
-
-# Make sure the GSI executable exists
-if [ ! -f "${EXECrtma3d}/${exefile_name_gsi}" ]; then
+# make sure executable exists
+if [ ! -f ${EXECrtma3d}/${exefile_name_gsi} ]; then
   ${ECHO} "ERROR: GSI Analysis executable '${EXECrtma3d}/${exefile_name_gsi}' does not exist!"
   exit 1
 fi
 
-# Check to make sure the number of processors for running GSI was specified
-if [ -z "${GSIPROC}" ]; then
-  ${ECHO} "ERROR: The variable $GSIPROC must be set to contain the number of processors to run GSI"
-  exit 1
-fi
+# Check to make sure required directory defined and existed
+check_if_defined "ENKF_FCST" "COMINhrrrdas" "HRRR_DIR" "OBS_DIR" "AIRCRAFT_REJECT" "SFCOBS_USELIST" "SFCOBS_PROVIDER" "EnsWgt"
+check_dirs_exist "ENKF_FCST" "COMINhrrrdas" "HRRR_DIR" "OBS_DIR" "AIRCRAFT_REJECT" "SFCOBS_USELIST" "SFCOBS_PROVIDER"
 
-# Check to make sure that fix direcory exists
-
-# Check to make sure that ENKF_FCST exists
-
-# Check to make sure that FULLCYC exists
-if [ ! "${FULLCYC}" ]; then
-  ${ECHO} "ERROR: FULLCYC '${FULLCYC}' does not exist"
-  exit 1
-fi
-
-# Make sure START_TIME is defined and in the correct format
-
-mm=$subcyc
-subhtime=$subcyc
-${ECHO} $PDY $cyc $mm
-  START_TIME=${START_TIME:-"{PDY} ${cyc}"}      # YYYYMMDD HH
-
-echo $START_TIME
-echo $subhtime
-if [ ! "${START_TIME}" ]; then
-  ${ECHO} "ERROR: \$START_TIME is not defined!"
-  exit 1
+if [ "${subcyc}" == "-1" ]; then #hourly run
+  SUBH_TIME='00'
+  tz_str=t${cyc}z
 else
-  if [ `${ECHO} "${START_TIME}" | ${AWK} '/^[[:digit:]]{10}$/'` ]; then
-    START_TIME=`${ECHO} "${START_TIME}" | ${SED} 's/\([[:digit:]]\{2\}\)$/ \1/'`
-  elif [ ! "`${ECHO} "${START_TIME}" | ${AWK} '/^[[:digit:]]{8}[[:blank:]]{1}[[:digit:]]{2}$/'`" ]; then
-    ${ECHO} "ERROR: start time, '${START_TIME}', is not in 'yyyymmddhh' or 'yyyymmdd hh' format"
-    exit 1
-  fi
-  START_TIME=`${DATE} -d "${START_TIME} ${subhtime} minutes"`
+  SUBH_TIME=${subcyc}
+  tz_str=t${cyc}${subcyc}z
 fi
-echo $START_TIME
+START_TIME=`${DATE} -d "${PDY} ${cyc} ${SUBH_TIME} minutes"`
 
 # Compute date & time components for the analysis time
-YYYYMMDDHHMU=`${DATE} +"%Y%m%d%H%M" -d "${START_TIME}"`
-YYYYJJJHH00=`${DATE} +"%Y%j%H00" -d "${START_TIME}"`
 YYYYMMDDHH=`${DATE} +"%Y%m%d%H" -d "${START_TIME}"`
-YYYYMMDD=`${DATE} +"%Y%m%d" -d "${START_TIME}"`
-YYYY=`${DATE} +"%Y" -d "${START_TIME}"`
-MM=`${DATE} +"%m" -d "${START_TIME}"`
-DD=`${DATE} +"%d" -d "${START_TIME}"`
-HH=`${DATE} +"%H" -d "${START_TIME}"`
+YYYYMMDDHHMM=`${DATE} +"%Y%m%d%H%M" -d "${START_TIME}"`
+time_1hour_ago=`${DATE} -d "${START_TIME} 1 hour ago" +%Y%m%d%H`
+time_str=`${DATE} "+%Y-%m-%d_%H_%M_%S" -d "${START_TIME}"`
+time_str2=`${DATE} "+%Y-%m-%d_%H_00_00" -d "${START_TIME}"`
 
+#----- enter working directory -------
+cd ${DATA}
+${ECHO} "enter working directory:${DATA}"
 
-if (((${HH} >= 00) && (${HH} <=  05))) ; then
-HHR=00
-HHRm1=12
-fi
-if (((${HH} >= 06) && (${HH} <=  11))) ; then
-HHR=06
-HHRm1=00
-fi
-if (((${HH} >= 12) && (${HH} <=  23))) ; then
-HHR=12
-HHRm1=06
-fi
-
-HH_cycp1=`echo ${PDYHH_cycp1} | cut -c 9-10`
-# Create the working directory and cd into it
-workdir=${DATAHOME}
-cd ${workdir}
-
-# Define the output log file depending on if this is the full or partial cycle
+# Define the loghistory file depending on if this is the full or partial cycle
 ifsoilnudge=.true.
+if [ "${envir}" == "esrl" ]; then #Jet
+  if [ "${FULLCYC}" == "0" ]; then
+    loghistoryfile=${COMROOT}/loghistory/HRRR_GSI_HYB_PCYC.log
+    ifsoilnudge=.true.
+  elif [ "${FULLCYC}" == "2" ]; then
+    loghistoryfile=${COMROOT}/loghistory/HRRR_GSI_HYB_early.log
+    ifsoilnudge=.true.
+  else
+    loghistoryfile=${COMROOT}/loghistory/HRRR_GSI_HYB.log
+    ifsoilnudge=.true.
+  fi
+fi
 
 # Bring over background field (it's modified by GSI so we can't link to it)
-time_str=`${DATE} "+%Y-%m-%d_%H_%M_%S" -d "${START_TIME}"`
-${ECHO} " time_str = ${time_str}"
-time_run=${time_str}
-
-# Look for bqckground from pre-forecast background
-if [ -r ${DATAHOME_BK}/${FGSrtma3d_FNAME} ]; then
-# copy the background to running directory (it is going to updatd by analysis)
-  cpfs ${DATAHOME_BK}/${FGSrtma3d_FNAME}    ./wrf_inout
-  ${ECHO} " Cycle ${YYYYMMDDHHMU}: GSI background=${DATAHOME_BK}/${FGSrtma3d_FNAME}"
+if [ "${subcyc}" == "-1" ]; then #hourly run
+   cycle_str=${YYYYMMDDHH}
 else
-# No background available so abort
-  ${ECHO} "${DATAHOME_BK}/${FGSrtma3d_FNAME} does not exist!!"
-  ${ECHO} "ERROR: No background file for analysis at ${time_run}!!!!"
-  ${ECHO} " Cycle ${YYYYMMDDHHMMMU}: GSI failed because of no background" >> ${pgmout}
+   cycle_str=${YYYYMMDDHHMM}
+fi
+
+# Look for background field for GSI analysis
+if [ "${envir}" == "esrl" ]; then #Jet expr runs
+  GSIbackground=${HRRR_DIR}/${time_1hour_ago}/wrfprd/wrfout_d01_${time_str}
+else
+  GSIbackground=${BKG_DIR}/${FGSrtma3d_FNAME}
+fi
+if [ -r ${GSIbackground} ]; then
+  cpfs ${GSIbackground} ./wrf_inout
+  ${ECHO} " Cycle ${cycle_str}: GSI background=${GSIbackground}"
+  if [ "${envir}" == "esrl" ]; then #Jet expr runs
+    ${ECHO} " Cycle ${cycle_str}: GSI background=${GSIbackground}" >> ${loghistoryfile}
+  fi
+else
+  # No background available so abort
+  ${ECHO} "${GSIbackground} does not exist!!"
+  ${ECHO} "FATAL ERROR: No background file for analysis at ${time_str}!!!!"
+  if [ "${envir}" == "esrl" ]; then #Jet expr runs
+    ${ECHO} " Cycle ${cycle_str}: GSI failed because of no background" >> ${loghistoryfile}
+  fi
   exit 1
 fi
 
-# Snow cover building and trimming currently set to run in the 00z cycle
-
-# Update SST currently set to run in the 01z cycle
-
 # Link to the prepbufr data
-
-if [ -r ${DATAOBSHOME}/newgblav.${YYYYMMDD}.rap.t${HH}${subcyc}z.prepbufr ] ; then
-  ${LN} -s ${DATAOBSHOME}/newgblav.${YYYYMMDD}.rap.t${HH}${subcyc}z.prepbufr ./prepbufr
-elif [ -r ${DATAOBSHOME}/rtma_ru.t${HH}${subcyc}z.prepbufr.tm00 ] ; then
-  ${LN} -s ${DATAOBSHOME}/rtma_ru.t${HH}${subcyc}z.prepbufr.tm00 ./prepbufr
+if [ -r ${OBS_DIR}/prepbufr ] ; then
+  ${LN} -sf ${OBS_DIR}/prepbufr ./prepbufr
 else
-  ${ECHO} "Warning: either ${DATAOBSHOME}/newgblav.${YYYYMMDD}.rap.t${HH}${subcyc}z.prepbufr or rap.t${HH}${subcyc}z.prepbufr.tm00 does not exist!"
+  ${ECHO} "Warning: ${OBS_DIR}/prepbufr does not exist"
 fi
 
-if [ -r "${DATAOBSHOME}/NSSLRefInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/NSSLRefInGSI.bufr ./refInGSI
-elif [ -r "${DATAOBSHOME}/hrrr.t${HH}${subcyc}z.NSSLRefInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/hrrr.t${HH}${subcyc}z.NSSLRefInGSI.bufr ./refInGSI
-elif [ -r "${DATAOBSHOME}/${RUN}.t${HH}${subcyc}z.NSSLRefInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/${RUN}.t${HH}${subcyc}z.NSSLRefInGSI.bufr ./refInGSI
+if [ -r "${OBS_DIR}/NSSLRefInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/NSSLRefInGSI.bufr ./refInGSI
+elif [ -r "${OBS_DIR}/hrrr.${tz_str}.NSSLRefInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/hrrr.${tz_str}.NSSLRefInGSI.bufr ./refInGSI
+elif [ -r "${OBS_DIR}/${RUN}.${tz_str}.NSSLRefInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/${RUN}.${tz_str}.NSSLRefInGSI.bufr ./refInGSI
 else
-  ${ECHO} "Warning: ${DATAOBSHOME}:NSSLRefInGSI.bufr does not exist!"
+  ${ECHO} "Warning: ${OBS_DIR}: NSSLRefInGSI.bufr does not exist!"
 fi
 
-if [ -r "${DATAOBSHOME}/LightningInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/LightningInGSI.bufr ./lghtInGSI
-elif [ -r "${DATAOBSHOME}/hrrr.t${HH}${subcyc}z.LightningInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/hrrr.t${HH}${subcyc}z.LightningInGSI.bufr ./lghtInGSI
-elif [ -r "${DATAOBSHOME}/rtma_ru.t${HH}${subcyc}z.lghtng.tm00.bufr_d" ]; then
-  ${LN} -s ${DATAOBSHOME}/rtma_ru.t${HH}${subcyc}z.lghtng.tm00.bufr_d ./lghtInGSI
-elif [ -r "${DATAOBSHOME}/${RUN}.t${HH}${subcyc}z.LightningInGSI_bufr.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/${RUN}.t${HH}${subcyc}z.LightningInGSI_bufr.bufr ./lghtInGSI
+if [ -r "${OBS_DIR}/LightningInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/LightningInGSI.bufr ./lghtInGSI
+elif [ -r "${OBS_DIR}/hrrr.{tz_str}.LightningInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/hrrr.{tz_str}.LightningInGSI.bufr ./lghtInGSI
+elif [ -r "${OBS_DIR}/${RUN}.{tz_str}.lghtng.tm00.bufr_d" ]; then
+  ${LN} -sf ${OBS_DIR}/${RUN}.{tz_str}.lghtng.tm00.bufr_d ./lghtInGSI
+elif [ -r "${OBS_DIR}/${RUN}.{tz_str}.LightningInGSI_bufr.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/${RUN}.{tz_str}.LightningInGSI_bufr.bufr ./lghtInGSI
 else
-  ${ECHO} "Warning: ${DATAOBSHOME}: LightningInGSI.bufr does not exist!"
+  ${ECHO} "Warning: ${OBS_DIR}: LightningInGSI.bufr does not exist!"
 fi
 
-
-if [ -r "${DATAOBSHOME}/NASALaRCCloudInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/NASALaRCCloudInGSI.bufr ./larcInGSI
-elif [ -r "${DATAOBSHOME}/hrrr.t${HH}${subcyc}z.NASALaRCCloudInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/hrrr.t${HH}${subcyc}z.NASALaRCCloudInGSI.bufr ./larcInGSI
-elif [ -r "${DATAOBSHOME}/rtma_ru.t${HH}${subcyc}z.lgycld.tm00.bufr_d" ]; then
-  ${LN} -s ${DATAOBSHOME}/rtma_ru.t${HH}${subcyc}z.lgycld.tm00.bufr_d ./larcInGSI
-elif [ -r "${DATAOBSHOME}/${RUN}.t${HH}${subcyc}z.NASALaRCCloudInGSI.bufr" ]; then
-  ${LN} -s ${DATAOBSHOME}/${RUN}.t${HH}${subcyc}z.NASALaRCCloudInGSI.bufr ./larcInGSI
+if [ -r "${OBS_DIR}/NASALaRCCloudInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/NASALaRCCloudInGSI.bufr ./larcInGSI
+elif [ -r "${OBS_DIR}/hrrr.{tz_str}.NASALaRCCloudInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/hrrr.{tz_str}.NASALaRCCloudInGSI.bufr ./larcInGSI
+elif [ -r "${OBS_DIR}/${RUN}.{tz_str}.NASALaRCCloudInGSI.bufr" ]; then
+  ${LN} -sf ${OBS_DIR}/${RUN}.{tz_str}.NASALaRCCloudInGSI.bufr ./larcInGSI
+elif [ -r "${OBS_DIR}/rtma_ru.{tz_str}.lgycld.tm00.bufr_d" ]; then
+  ${LN} -sf ${OBS_DIR}/rtma_ru.{tz_str}.lgycld.tm00.bufr_d ./larcInGSI
 else
-  ${ECHO} "Warning: ${DATAOBSHOME}: NASALaRCCloudInGSI.bufr does not exist!"
+  ${ECHO} "Warning: ${OBS_DIR}: NASALaRCCloudInGSI.bufr does not exist!"
 fi
 
-# Set runtime and save directories
-export endianness=Big_Endian
+if [ "${envir}" != "esrl" ]; then #WCOSS
+  # Set runtime and save directories
+  export endianness=Big_Endian
 
-# Set variables used in script
-#   ncp is cp replacement, currently keep as /bin/cp
-ncp=/bin/cp
+  # Set variables used in script
+  #   ncp is cp replacement, currently keep as /bin/cp
+  ncp=/bin/cp
 
-export HYB_ENS=".true."
+  export HYB_ENS=".true."
 
-# Get Fv3GDAS Enkf files
-# We expect 80 total files to be present (80 enkf)
-export nens=80
+  # Get Fv3GDAS Enkf files
+  # We expect 80 total files to be present (80 enkf)
+  export nens=80
 
-# Not using FGAT or 4DEnVar, so hardwire nhr_assimilation to 3
-export nhr_assimilation=03
-##typeset -Z2 nhr_assimilation
+  # Not using FGAT or 4DEnVar, so hardwire nhr_assimilation to 3
+  export nhr_assimilation=03
+  ##typeset -Z2 nhr_assimilation
 
 
-python ${UTILrtma3d_dev}/getbest_EnKF_FV3GDAS.py -v $YYYYMMDDHH --exact=no --minsize=${nens} -d ${COMINGDAS}/enkfgdas -m no -o filelist${nhr_assimilation} --o3fname=gfs_sigf${nhr_assimilation} --gfs_nemsio=yes
- 
+  python ${UTILrtma3d_dev}/getbest_EnKF_FV3GDAS.py -v $YYYYMMDDHH --exact=no --minsize=${nens} -d ${COMINGDAS}/enkfgdas -m no -o filelist${nhr_assimilation} --o3fname=gfs_sigf${nhr_assimilation} --gfs_nemsio=yes
+   
 
-#Check to see if ensembles were found 
-numfiles=`cat filelist03 | wc -l`
+  #Check to see if ensembles were found 
+  numfiles=`cat filelist03 | wc -l`
 
-if [ $numfiles -ne 80 ]; then
-  echo "Ensembles not found - turning off ifhyb!"
-  export ifhyb=".false."
-else
-#   we have 80 files, figure out if they are all the right size
-#   if not, set ifhyb=false
-    cp ${UTILrtma3d_dev}/convert.sh .
-    ${UTILrtma3d_dev}/check_enkf_size.sh
+  if [ $numfiles -ne 80 ]; then
+    echo "Ensembles not found - turning off ifhyb!"
+    export ifhyb=".false."
+  else
+  #   we have 80 files, figure out if they are all the right size
+  #   if not, set ifhyb=false
+      cp ${UTILrtma3d_dev}/convert.sh .
+      ${UTILrtma3d_dev}/check_enkf_size.sh
+  fi
+else #ESRL expr. runs
+## 
+## Find closest GFS EnKF forecast to analysis time
+# Make a list of the latest GFS EnKF ensemble
+stampcycle=`date -d "${START_TIME}" +%s`
+minHourDiff=100
+loops="009"
+for loop in $loops; do
+  for timelist in `ls ${ENKF_FCST}/*.gdas.t*z.atmf${loop}s.mem080.nemsio`; do
+    availtimeyy=`basename ${timelist} | cut -c 1-2`
+    availtimeyyyy=20${availtimeyy}
+    availtimejjj=`basename ${timelist} | cut -c 3-5`
+    availtimemm=`date -d "${availtimeyyyy}0101 +$(( 10#${availtimejjj} - 1 )) days" +%m`
+    availtimedd=`date -d "${availtimeyyyy}0101 +$(( 10#${availtimejjj} - 1 )) days" +%d`
+    availtimehh=`basename ${timelist} | cut -c 6-7`
+    availtime=${availtimeyyyy}${availtimemm}${availtimedd}${availtimehh}
+    AVAIL_TIME=`${ECHO} "${availtime}" | ${SED} 's/\([[:digit:]]\{2\}\)$/ \1/'`
+    AVAIL_TIME=`${DATE} -d "${AVAIL_TIME}"`
+
+    stamp_avail=`date -d "${AVAIL_TIME} ${loop} hours" +%s`
+
+    hourDiff=`echo "($stampcycle - $stamp_avail) / (60 * 60 )" | bc`;
+    if [[ ${stampcycle} -lt ${stamp_avail} ]]; then
+       hourDiff=`echo "($stamp_avail - $stampcycle) / (60 * 60 )" | bc`;
+    fi
+
+    if [[ ${hourDiff} -lt ${minHourDiff} ]]; then
+       minHourDiff=${hourDiff}
+       enkfcstname=${availtimeyy}${availtimejjj}${availtimehh}00.gdas.t${availtimehh}z.atmf${loop}s
+    fi
+  done
+done
+EYYYYMMDD=$(echo ${availtime} | cut -c1-8)
+EHH=$(echo ${availtime} | cut -c9-10)
+${LS} ${ENKF_FCST}/${enkfcstname}.mem???.nemsio > filelist03
+#${LS} ${ENKF_FCST}/${enkfcstname}.mem???.nemsio > filelist.tmp
+#head -n 36 filelist.tmp > filelist03
+
+## 
+## Link to pre-processed GFS EnKF forecast members
+##
+# for mem in `ls ${DATAROOT}/gfsenkf/enspreproc_arw_mem???`
+# do
+#   memname=`basename ${mem}`
+#   ${LN} -sf ${mem} ${memname}
+# done
+# ${LS} enspreproc_arw_mem??? > filelist
+
 fi
 
-if [ ${HRRRDAS_BEC} -gt 0 ]; then
+if [ ${HRRRDAS_BEC} -eq 1 ]; then
   ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_BEC}, so HRRRDAS will be used if available"
   #----------------------------------------------------
   # generate list of HRRRDAS members for ensemble covariances
-  # Use 1-hr forecasts from the HRRRDAS cyclin
+  # Use 1-hr forecasts from the HRRRDAS cycling
+  if [ "${envir}" != "esrl" ]; then #WCOSS
+    ${LS} ${COMINhrrrdas}/hrrrdas_small_d02_${YYYYMMDD}${cyc}00f01_mem000${c} > filelist.hrrrdas
+  elif [ ${HRRRDAS_SMALL} -eq 1 ]; then
+    ${LS} ${COMINhrrrdas}/${time_1hour_ago}/wrfprd_mem????/wrfout_small_d02_${time_str2} > filelist.hrrrdas
+  else
+    ${LS} ${COMINhrrrdas}/${time_1hour_ago}/wrfprd_mem????/wrfout_d02_${time_str2} > filelist.hrrrdas
+  fi
   c=1
-  hrrre_file=${COMINhrrrdas}/hrrrdas_small_d02_${YYYYMMDD}${cyc}00f01_mem0001
-  ${LS} ${COMINhrrrdas}/hrrrdas_small_d02_${YYYYMMDD}${cyc}00f01_mem000${c} > filelist.hrrrdas
-  ${LN} -sf ${hrrre_file} wrf_en001
-  c=2
   while [[ $c -le 36 ]]; do
    if [ $c -lt 10 ]; then
     cc="0"$c
    else
     cc=$c
    fi
-   hrrre_file=${COMINhrrrdas}/hrrrdas_small_d02_${YYYYMMDD}${cyc}00f01_mem00${cc}
-   ${LS} ${COMINhrrrdas}/hrrrdas_small_d02_${YYYYMMDD}${cyc}00f01_mem00${cc} >> filelist.hrrrdas
+   if [ "${envir}" != "esrl" ]; then #WCOSS
+     hrrre_file=${COMINhrrrdas}/hrrrdas_small_d02_${YYYYMMDD}${cyc}00f01_mem00${cc}
+   elif [ ${HRRRDAS_SMALL} -eq 1 ]; then
+     hrrre_file=${COMINhrrrdas}/${time_1hour_ago}/wrfprd_mem00${cc}/wrfout_small_d02_${time_str2}
+   else
+     hrrre_file=${COMINhrrrdas}/${time_1hour_ago}/wrfprd_mem00${cc}/wrfout_d02_${time_str2}
+   fi
    ${LN} -sf ${hrrre_file} wrf_en0${cc}
    ((c = c + 1))
   done
 else
   ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_BEC}, so HRRRDAS will NOT be used"
-  touch filelist.hrrrdas #so as to avoid "no such file" error message
+  ${TOUCH} filelist.hrrrdas #so as to avoid "no such file" error message
 fi
 
 # Determine if hybrid option is available
@@ -267,7 +262,7 @@ if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC 
   nummem=${hrrrmem}
   cp filelist.hrrrdas filelist03
 
-  beta1_inv=0.10 #0.15
+  beta1_inv=$(( 1 - $EnsWgt  ))
   ifhyb=.true.
   regional_ensemble_option=3
   grid_ratio_ens=1
@@ -284,10 +279,6 @@ elif [[ ${nummem} -eq 80 ]]; then
   ens_fast_read=.false. 
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses GDAS directly with n_ens=${nummem}" >> ${pgmout}
 fi
-
-# Determine if hybrid option is available
-#beta1_inv=1.0
-#ifhyb=.false.
 
 # Set fixed files
 #   berror   = forecast model background error statistics
@@ -308,10 +299,8 @@ fi
 anavinfo=${FIXgsi}/anavinfo_arw_netcdf
 BERROR=${FIXgsi}/rap_berror_stats_global_RAP_tune
 SATANGL=${FIXgsi}/global_satangbias.txt
-#SATINFO=${FIXgsi}/global_satinfo.txt
-SATINFO=${FIXgsi}/rap_global_satinfo.txt
+SATINFO=${FIXgsi}/global_satinfo.txt
 CONVINFO=${FIXgsi}/nam_regional_convinfo_RAP.txt
-#CONVINFO=${FIXgsi}/convinfo_NoUpperAirObs
 OZINFO=${FIXgsi}/global_ozinfo.txt    
 PCPINFO=${FIXgsi}/global_pcpinfo.txt
 OBERROR=${FIXgsi}/nam_errtable.r3dv
@@ -336,7 +325,7 @@ emiscoef_VISice=${FIXcrtm}/NPOESS.VISice.EmisCoeff.bin
 emiscoef_VISland=${FIXcrtm}/NPOESS.VISland.EmisCoeff.bin
 emiscoef_VISsnow=${FIXcrtm}/NPOESS.VISsnow.EmisCoeff.bin
 emiscoef_VISwater=${FIXcrtm}/NPOESS.VISwater.EmisCoeff.bin
-emiscoef_MWwater=${FIXcrtm}/FASTEM5.MWwater.EmisCoeff.bin
+emiscoef_MWwater=${FIXcrtm}/FASTEM6.MWwater.EmisCoeff.bin
 aercoef=${FIXcrtm}/AerosolCoeff.bin
 cldcoef=${FIXcrtm}/CloudCoeff.bin
 
@@ -348,7 +337,7 @@ ln -s $emiscoef_VISice ./NPOESS.VISice.EmisCoeff.bin
 ln -s $emiscoef_VISland ./NPOESS.VISland.EmisCoeff.bin
 ln -s $emiscoef_VISsnow ./NPOESS.VISsnow.EmisCoeff.bin
 ln -s $emiscoef_VISwater ./NPOESS.VISwater.EmisCoeff.bin
-ln -s $emiscoef_MWwater ./FASTEM5.MWwater.EmisCoeff.bin
+ln -s $emiscoef_MWwater ./FASTEM6.MWwater.EmisCoeff.bin
 ln -s $aercoef  ./AerosolCoeff.bin
 ln -s $cldcoef  ./CloudCoeff.bin
 
@@ -358,21 +347,13 @@ for file in `awk '{if($1!~"!"){print $1}}' ./satinfo | sort | uniq` ;do
    ln -s ${FIXcrtm}/${file}.TauCoeff.bin ./
 done
 
-# Get aircraft reject list
-#cp ${AIRCRAFT_REJECT}/current_bad_aircraft.txt current_bad_aircraft
-ln -sf /gpfs/dell2/emc/modeling/noscrub/Gang.Zhao/Data_RTMA3D_Jet/amb-verif/acars_RR/amdar_reject_lists/current_bad_aircraft.txt      ./current_bad_aircraft.txt 
-ln -sf /gpfs/dell2/emc/modeling/noscrub/Edward.Colon/FixData/obsuselist/sfcobs_provider/gsd_sfcobs_provider.txt                 ./gsd_sfcobs_provider.txt
-ln -sf /gpfs/dell2/emc/modeling/noscrub/Gang.Zhao/Data_RTMA3D_Jet/amb-verif/mesonet_uselists/current_mesonet_uselist.txt              ./current_mesonet_uselist.txt
-#sfcuselists_path=${SFCOBS_USELIST}
-#sfcuselists=current_mesonet_uselist.txt
-#sfcuselists=${YYYY}-${MM}-${DD}_meso_uselist.txt
-#cp ${sfcuselists_path}/${sfcuselists} gsd_sfcobs_uselist.txt
+# Get aircraft reject list, mesonet_uselist, sfcobs_provider
+${CP} ${AIRCRAFT_REJECT}/current_bad_aircraft.txt current_bad_aircraft
+${CP} ${SFCOBS_USELIST}/current_mesonet_uselist.txt gsd_sfcobs_uselist.txt
+${CP} ${SFCOBS_PROVIDER}/gsd_sfcobs_provider.txt gsd_sfcobs_provider.txt
 
-#cp ${SFCOBS_PROVIDER}/gsd_sfcobs_provider.txt gsd_sfcobs_provider.txt
-# Only need this file for single obs test
-#ln -sf current_mesonet_uselist.txt gsd_sfcobs_provider.txt
 bufrtable=${FIXgsi}/prepobs_prep.bufrtable
-cp $bufrtable ./prepobs_prep.bufrtable
+${CP} $bufrtable ./prepobs_prep.bufrtable
 
 # Set some parameters for use by the GSI executable and to build the namelist
 export JCAP=${JCAP:-62}
@@ -395,95 +376,77 @@ else
   ens_v=1 #3
 fi
 
-ndatrap=67  #62 ?
-
-# 3DVar and Cloud analysis in one-step
-#grid_ratio=${GSI_grid_ratio_in_var:-1}
-#cloudanalysistype=1
-
 # option for hybrid vertical coordinate (HVC) in WRF-ARW
-
-if [ "$NCDUMP" ] ; then
-  n_c3f=`$NCDUMP -h ./wrf_inout | grep -i "C3F:" | wc -l`
-  n_c4f=`$NCDUMP -h ./wrf_inout | grep -i "C4F:" | wc -l`
-  n_c3h=`$NCDUMP -h ./wrf_inout | grep -i "C3H:" | wc -l`
-  n_c4h=`$NCDUMP -h ./wrf_inout | grep -i "C4H:" | wc -l`
-  if [[ $n_c3f -gt "1"  && $n_c4f -gt "1" && $n_c3h -gt "1" && $n_c4h -gt "1" ]] ; then
-    hybridcord=".true."
+if [ "${envir}" != "esrl" ]; then #WCOSS
+  if [ "$NCDUMP" ] ; then
+    n_c3f=`$NCDUMP -h ./wrf_inout | grep -i "C3F:" | wc -l`
+    n_c4f=`$NCDUMP -h ./wrf_inout | grep -i "C4F:" | wc -l`
+    n_c3h=`$NCDUMP -h ./wrf_inout | grep -i "C3H:" | wc -l`
+    n_c4h=`$NCDUMP -h ./wrf_inout | grep -i "C4H:" | wc -l`
+    if [[ $n_c3f -gt "1"  && $n_c4f -gt "1" && $n_c3h -gt "1" && $n_c4h -gt "1" ]] ; then
+      hybridcord=".true."
+    else
+      hybridcord=".false."
+    fi
   else
-    hybridcord=".false."
+    if [ ${YYYYMMDDHH} -lt "2018071118" ] ; then
+      hybridcord=".false."
+    else
+      hybridcord=".true."
+    fi
   fi
-else
-  if [ ${YYYYMMDDHHMU} -lt "201807111800" ] ; then
-    hybridcord=".false."
-  else
-    hybridcord=".true."
-  fi
+  echo "HVC option is $hybridcord"
 fi
-echo "HVC option is $hybridcord"
 
+${CP} ${PARMgsi}/hybens_info ./
 # Build the GSI namelist on-the-fly
-cp ${PARMgsi}/gsiparm.anl.sh ./
-. ./gsiparm.anl.sh
+${CP} ${PARMgsi}/gsiparm.anl.sh ./
+source ./gsiparm.anl.sh
 cat << EOF > gsiparm.anl
 $gsi_namelist
 EOF
 
 ## satellite bias correction
-cp ${FIXgsi}/rap_satbias_starting_file.txt ./satbias_in
-cp ${FIXgsi}/rap_satbias_pc_starting_file.txt ./satbias_pc
+${CP} ${FIXgsi}/rap_satbias_starting_file.txt ./satbias_in
+${CP} ${FIXgsi}/rap_satbias_pc_starting_file.txt ./satbias_pc
 
 # Run GSI
-pgm=${RUN}_gsianl
+export pgm="rtma3d_gsi"
 . prep_step
-
 startmsg
-msg="***************************************************************************"
+msg="***********************************************************"
 postmsg "$jlogfile" "$msg"
-msg="  begin gsi analysis  : variational + cloud analysis in one-step"
+if [ "${run_gsi_2times}" == "NO" ];  then
+  msg="  begin gsi analysis (var+cloudanx)"
+else
+  msg="  begin first gsi analysis - variational analysis"
+fi
 postmsg "$jlogfile" "$msg"
-msg="***************************************************************************"
+msg="***********************************************************"
 postmsg "$jlogfile" "$msg"
 
-# Save a copy of the GSI executable in the workdir
-${CP} ${EXECrtma3d}/${exefile_name_gsi}   ./rtma3d_gsi
-
- runline="${MPIRUN}         ./rtma3d_gsi"
-$runline < gsiparm.anl >> ${pgmout} 2>errfile
-export err=$? ; err_chk
-
-#===========================================================#
-# error checking used in GSD script
-#===========================================================#
-export pgmout_stdout="stdout"
-cat ${pgmout} > ${pgmout_stdout}
-if [ -f errfile ] ; then
-    cat errfile >> ${pgmout_stdout}
+if [ "${envir}" == "esrl" ]; then #Jet
+  CP_LN="${LN} -sf"
+else
+  CP_LN=${CP}
 fi
-
-export error=$err
-if [ ${error} -ne 0 ]; then
-  ${ECHO} "ERROR: ${GSI} crashed  Exit status=${error}"
-  cp -p ${pgmout_stdout}  ../.
-  exit ${error}
+${CP_LN} ${EXECrtma3d}/${exefile_name_gsi} ${pgm}
+if [ "${envir}" == "esrl" ];  then ##GSI on Jet needs special treatment
+  [[ "$-" == *"x"* ]] && set +x && prev_x="YES"
+  module use -a /contrib/wrap-mpi/modulefiles > /dev/null
+  module load wrap-mpi >/dev/null
+  [[ "${prev_x}" == "YES"  ]] && set -x
+  mpirun ${DATA}/${pgm} < gsiparm.anl > ${pgmout} 2>errfile
+else
+  ${MPIRUN} ${pgm} < gsiparm.anl > ${pgmout} 2>errfile
 fi
-
-ls -l > GSI_workdir_list
-
-# Look for successful completion messages in rsl files
-nsuccess=`${TAIL} -200 ${pgmout_stdout} | ${AWK} '/PROGRAM GSI_ANL HAS ENDED/' | ${WC} -l`
-ntotal=1 
-${ECHO} "Found ${nsuccess} of ${ntotal} completion messages"
-if [ ${nsuccess} -ne ${ntotal} ]; then
-   ${ECHO} "ERROR: ${GSI} did not complete sucessfully  Exit status=${error}"
-   cp -p ${pgmout_stdout}  ../.
-   cp GSI_workdir_list ../.
-   if [ ${error} -ne 0 ]; then
-     exit ${error}
-   else
-     exit 1
-   fi
-fi
+##save some information for possible debugging before err_chk
+${CAT} fort.* >   fits_${cycle_str}.txt
+#${LS} -l > GSI_workdir_list
+${CAT} errfile >> ${pgmout}
+#${MV} ${pgmout} ${pgmout}.var
+${CP} -p fits_${cycle_str}.txt ${COMOUTgsi_rtma3d}
+export err=$?; err_chk
 
 # Loop over first and last outer loops to generate innovation
 # diagnostic files for indicated observation types (groups)
@@ -511,44 +474,91 @@ esac
    for type in $listall; do
       count=`ls pe*.${type}_${loop}* | wc -l`
       if [[ $count -gt 0 ]]; then
-         `cat pe*.${type}_${loop}* > diag_${type}_${string}.${YYYYMMDDHHMU}`
+         `${CAT} pe*.${type}_${loop}* > diag_${type}_${string}.${cycle_str}`
       fi
    done
 done
 
-# save results from 1st run
-${CP} fort.201    fit_p1.${YYYYMMDDHHMU}
-${CP} fort.202    fit_w1.${YYYYMMDDHHMU}
-${CP} fort.203    fit_t1.${YYYYMMDDHHMU}
-${CP} fort.204    fit_q1.${YYYYMMDDHHMU}
-${CP} fort.207    fit_rad1.${YYYYMMDDHHMU}
-cat   fort.* >    fits_${YYYYMMDDHHMU}.txt
-${CP} -p fort.220 minimization_fort220.${YYYYMMDDHHMU}
-# cat fort.* > ${COMOUT}/fits_${YYYYMMDDHH}.txt
+## link fort files with user-friendly file name
+if [ "${envir}" != "esrl" ]; then #wcoss
+  ${LN} -sf fort.201    fit_p1.${cycle_str}
+  ${LN} -sf fort.202    fit_w1.${cycle_str}
+  ${LN} -sf fort.203    fit_t1.${cycle_str}
+  ${LN} -sf fort.204    fit_q1.${cycle_str}
+  ${LN} -sf fort.207    fit_rad1.${cycle_str}
+  ${LN} -sf fort.220 minimization_fort220.${cycle_str}
+fi
 
+###### second GSI run if needed
+if [ "${run_gsi_2times}" == "YES" ];  then
+  mv gsiparm.anl gsiparm.anl_var
+  mv sigf03 sigf03_step1
+  mv siganl sigf03
+  grid_ratio=1
+  cloudanalysistype=6
+  ifhyb=.false.
+  # Build the GSI namelist on-the-fly
+  source ./gsiparm.anl.sh
+cat << EOF > gsiparm.anl
+$gsi_namelist
+EOF
+  . prep_step
+  startmsg
+  msg="***********************************************************"
+  postmsg "$jlogfile" "$msg"
+  msg="  begin second step gsi analysis: cloud analysis"
+  postmsg "$jlogfile" "$msg"
+  msg="***********************************************************"
+  postmsg "$jlogfile" "$msg"
+  ${ECHO} -e "\n\n@@@@@@@@@ second GSI run standard output\n" >> ${pgmout}
+  if [ "${envir}" == "esrl" ];  then ##GSI on Jet needs special treatment
+    [[ "$-" == *"x"* ]] && set +x && prev_x="YES"
+    module use -a /contrib/wrap-mpi/modulefiles > /dev/null
+    module load wrap-mpi >/dev/null
+    [[ "${prev_x}" == "YES"  ]] && set -x
+    mpirun ${DATA}/${pgm} < gsiparm.anl >> ${pgmout} 2>errfile
+  else
+    ${MPIRUN} ${pgm} < gsiparm.anl >> ${pgmout} 2>errfile
+  fi
+  #${LS} -l > GSI_workdir_list
+  ${CAT} errfile >> ${pgmout}
+  ${ECHO} -e "\n\n -- End of second GSI --\n" >> ${pgmout}
+  #${CP} -p ${pgmout} ${COMOUTgsi_rtma3d}/${pgmout}.cloudana #this output should be in $LLOG_PGMOUT
+  export err=$?; err_chk
+
+fi ###### second GSI run
 
 # Saving ANALYSIS, DIAG, Obs-Fitting files TO COM2 DIRECTORY AS PRODUCT for archive
-${CP} -p ${DATA}/wrf_inout                  ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
-${CP} -p ${pgmout_stdout}                   ${COMOUTgsi_rtma3d}/${pgmout_stdout}_gsianl.${YYYYMMDDHHMU}
-${CP} -p fits_${YYYYMMDDHHMU}.txt             ${COMOUTgsi_rtma3d}/fits_${YYYYMMDDHHMU}.txt
-${CP} -p minimization_fort220.${YYYYMMDDHHMU} ${COMOUTgsi_rtma3d}/minimization_fort220.${YYYYMMDDHHMU}
-${CP} -p gsiparm.anl                        ${COMOUTgsi_rtma3d}/gsiparm.anl.${YYYYMMDDHHMU}
-${CP} -p diag_*                             ${COMOUTgsi_rtma3d}/
+${CP} -p gsiparm.anl  ${COMOUTgsi_rtma3d}/gsiparm.anl_${cycle_str}
+${TAR} -zcvf ${COMOUTgsi_rtma3d}/diag_${cycle_str}.tgz diag_*
 
-tar -zcvf obsfit_fort220.tgz  ./fort.* ./fit_*
-${CP} -p  obsfit_fort220.tgz                 ${COMOUTgsi_rtma3d}
-tar -zcvf misc_info.tgz       ./*info ./errtable ./prepobs_prep.bufrtable  ./*bias*  ./current_bad_aircraft ./gsd_sfcobs_uselist.txt ./gsd_sfcobs_provider.txt ./GSI_workdir_list
-${CP} -p  misc_info.tgz                      ${COMOUTgsi_rtma3d}
-gzip ${COMOUTgsi_rtma3d}/diag_*
+if [ "${envir}" != "esrl" ]; then #wcoss
+  ${MV} -p ${DATA}/wrf_inout                  ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+  ${CP} -p minimization_fort220.${cycle_str} ${COMOUTgsi_rtma3d}
+  ${CP} -p diag_*                             ${COMOUTgsi_rtma3d}
+  ${TAR} -zcvf obsfit_fort220.tgz  ./fort.* ./fit_*
+  ${CP} -p  obsfit_fort220.tgz                ${COMOUTgsi_rtma3d}
+  tar -zcvf misc_info.tgz  ./*info ./errtable ./prepobs_prep.bufrtable  ./*bias*  \
+    ./current_bad_aircraft ./gsd_sfcobs_uselist.txt ./gsd_sfcobs_provider.txt ./GSI_workdir_list
+  ${CP} -p  misc_info.tgz                      ${COMOUTgsi_rtma3d}
+  gzip ${COMOUTgsi_rtma3d}/diag_*
 
-# extra backup (NOT necessary)
-#${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
-#${CP} -p  ${pgmout_stdout}                       ${COMOUT}/${pgmout_stdout}_gsianl.${YYYYMMDDHHMU}
-#${CP} -p  fits_${YYYYMMDDHHMU}.txt                 ${COMOUT}/fits_${YYYYMMDDHHMU}.txt
+  # extra backup (NOT necessary)
+  #${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
+  #${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
+  #${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
+else
+  tar cvfz fixparm_gsi.${cycle_str}.tgz *info gsd*txt filelist03 satbias* berror_stats  \
+      current_bad_aircraft errtable gsiparm.anl
+  ${CP} -p fixparm_gsi.${cycle_str}.tgz ${LOG_PGMOUT}
+  ${CP} -p fixparm_gsi.${cycle_str}.tgz ${COMOUTgsi_rtma3d}
+fi
 
-#/bin/rm -f ${DATA}/wrf_inout
-/bin/rm -f ${DATA}/sig*
-/bin/rm -f ${DATA}/obs*
-/bin/rm -f ${DATA}/pe*
+${RM} -f ${DATA}/sig*
+${RM} -f ${DATA}/obs*
+${RM} -f ${DATA}/pe*
+
+msg="JOB $job FOR $RUN HAS COMPLETED NORMALLY"
+postmsg "$jlogfile" "$msg"
 
 exit 0

--- a/scripts/exrtma3d_obsprep_cloud.ksh
+++ b/scripts/exrtma3d_obsprep_cloud.ksh
@@ -1,79 +1,69 @@
-#!/bin/ksh
-############################################################################
-
+#!/bin/ksh --login
 set -x
+
 # make sure executable exists
 if [ ! -f ${EXECrtma3d}/${exefile_name_cloud} ] ; then
   ${ECHO} "ERROR: NASA cloud obs prcoessing executable '${EXECrtma3d}/${exefile_name_cloud}' does not exist!"
   exit 1
 fi
 
-# working directory
-workdir=${DATA}
-cd ${workdir}
+if [ ! "${NASALARC_DATA}" ]; then
+  ${ECHO} "ERROR: \$NASALARC_DATA is not defined!"
+  exit 1
+fi
+if [ ! -d "${NASALARC_DATA}" ]; then
+  ${ECHO} "ERROR: NASALARC_DATA directory '${NASALARC_DATA}' does not exist!"
+  exit 1
+fi
 
-# export MV2_ON_DEMAND_THRESHOLD=256    # if load module mvapich2 ?
-
-mm=$subcyc
-subhtime=$subcyc
-${ECHO} $PDY $cyc $mm
-# START_TIME="${PDY}${cyc}"      # YYYYMMDDHH
-  START_TIME=${START_TIME:-"{PDY} ${cyc}"}      # YYYYMMDD HH
-# START_TIME="${PDY} ${cyc} ${subcyc} minutes"  # YYYYMMDD HH MN 
-
-${ECHO} "${START_TIME}"
-echo `echo "${START_TIME}" | ${AWK} '/^[[:digit:]]{10}$/'`
- if [ `echo "${START_TIME}" | ${AWK} '/^[[:digit:]]{10}$/'` ]; then
-   START_TIME=`echo "${START_TIME}" | ${SED} 's/\([[:digit:]]\{2\}\)$/ \1/'`
- elif [ ! "`echo "${START_TIME}" | ${AWK} '/^[[:digit:]]{8}[[:blank:]]{1}[[:digit:]]{2}$/'`" ]; then
-   echo "FATAL ERROR: start time, '${START_TIME}', is not in 'yyyymmddhh' or 'yyyymmdd hh' format"
-   err_exit 1
- fi
- START_TIME=`${DATE} -d "${START_TIME} ${subhtime} minutes"`
-echo $START_TIME
+if [ "${subcyc}" == "-1" ]; then #hourly run
+  SUBH_TIME='00'
+  tz_str=t${cyc}z
+else
+  SUBH_TIME=${subcyc}
+  tz_str=t${cyc}${subcyc}z
+fi
+START_TIME=`${DATE} -d "${PDY} ${cyc} ${SUBH_TIME} minutes"`
 
 # Compute date & time components for the analysis time
-YYYYJJJHH00=`${DATE} +"%Y%j%H00" -d "${START_TIME}"`
 YYYYMMDDHH=`${DATE} +"%Y%m%d%H" -d "${START_TIME}"`
-YYYY=`${DATE} +"%Y" -d "${START_TIME}"`
-MM=`${DATE} +"%m" -d "${START_TIME}"`
-DD=`${DATE} +"%d" -d "${START_TIME}"`
+YYYYJJJHH=`${DATE} +"%Y%j%H" -d "${START_TIME}"`
 HH=`${DATE} +"%H" -d "${START_TIME}"`
 
-typeset -Z2 mm mmp1 mmp2 mmp3              # <<-- "-Z2" only work for K-Shell
-mm=`${DATE} +"%M" -d "${START_TIME}"`
-mmp1=$((${mm}+1))
-mmp2=$((${mm}+2))
-mmp3=$((${mm}+3))
-# mm=`printf "%2.2i\n" $mm`
-# mmp1=`printf "%2.2i\n" $mmp1`
-# mmp2=`printf "%2.2i\n" $mmp2`
-# mmp3=`printf "%2.2i\n" $mmp3`
+#----- enter working directory -------
+cd ${DATA}
+${ECHO} "enter working directory:${DATA}"
 
-ymd=`${DATE} +"%Y%m%d" -d "${START_TIME}"`
-ymdh=${YYYYMMDDHH}
-hh=$HH
+# BUFR Table including the description for HREF
+${LN} -sf ${FIXgsi}/prepobs_prep_RAP.bufrtable ./prepobs_prep.bufrtable
+if [ ! -s "./prepobs_prep.bufrtable" ]; then
+  ${ECHO} "prepobs_prep.bufrtable does not exist or not readable"
+  exit 1
+fi
 
-# BUFR Table includingthe description for HREF
-${CP} -p ${FIXgsi}/prepobs_prep_RAP.bufrtable   ./prepobs_prep.bufrtable
 # WPS GEO_GRID Data
-${LN} -s ${FIXwps}/hrrr_geo_em.d01.nc           ./geo_em.d01.nc 
+${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc ./geo_em.d01.nc 
+if [ ! -s "./geo_em.d01.nc" ]; then
+  ${ECHO} "geo_em.d01.nc does not exist or not readable"
+  exit 1 
+fi
 
-#
-#--- 
-#
+# print parameters for linking/processing
+${ECHO} "START_TIME: "${START_TIME}
+${ECHO} "SUBH_TIME: "${SUBH_TIME}
+${ECHO} "YYYYMMDDHH: "${YYYYMMDDHH}
 
-# find rap bufr lgycld data file and link to the bufr file
-  if [ -s $COMINrap/rtma_ru.t${cyc}${subcyc}z.lgycld.tm00.bufr_d ] ; then
-    ${CP} -p $COMINrap/rtma_ru.t${cyc}${subcyc}z.lgycld.tm00.bufr_d ./rtma_ru.t${cyc}${subcyc}z.lgycld.tm00.bufr_d
-    ${LN} -sf ./rtma_ru.t${cyc}${subcyc}z.lgycld.tm00.bufr_d ./NASA_LaRC_cloud.bufr
-  else
-    echo 'No bufr file found for nasa LaRC cloud data processing'
-  fi
+# Link to the NASA LaRC cloud data
+if [ "${HH}" = 12 ] || [ "${HH}" = "00" ] ; then
+  ${LN} -sf ${NASALARC_DATA}/${YYYYMMDDHH}.rap_e.t${HH}z.lgycld.tm00.bufr_d ./NASA_LaRC_cloud.bufr
+else
+  ${LN} -sf ${NASALARC_DATA}/${YYYYMMDDHH}.rap.t${HH}z.lgycld.tm00.bufr_d ./NASA_LaRC_cloud.bufr
+fi
+if [ ! -s "NASA_LaRC_cloud.bufr" ]; then
+  ${ECHO} "./NASA_LaRC_cloud.bufr does not exist or not readable"
+  exit 1
+fi
 
-  echo ${PDY}${cyc} > ./nasaLaRC_cycle_date
-  YYYYMMDDHH=${PDY}${cyc}
-# echo ${YYYYMMDDHH} > ./nasaLaRC_cycle_date
 # Build the namelist on-the-fly
 ${CAT} << EOF > namelist_nasalarc
 &SETUP
@@ -84,36 +74,42 @@ ${CAT} << EOF > namelist_nasalarc
 /
 EOF
 
-# Run process lightning
-  pgm=${RUN}_cloud
-  . prep_step
+# Run obs processor
+export pgm="rtma3d_process_cloud"
+. prep_step
+startmsg
+msg="***********************************************************"
+postmsg "$jlogfile" "$msg"
+msg="  begin processing NASA LaRC cloud data"
+postmsg "$jlogfile" "$msg"
+msg="***********************************************************"
+postmsg "$jlogfile" "$msg"
 
-  startmsg
-  msg="***********************************************************"
-  postmsg "$jlogfile" "$msg"
-  msg="  begin pre-processing RAP bufr lightning data"
-  postmsg "$jlogfile" "$msg"
-  msg="***********************************************************"
-  postmsg "$jlogfile" "$msg"
+if [ "${envir}" == "esrl" ]; then #Jet
+  CP_LN="${LN} -sf"
+else
+  CP_LN=${CP}
+fi
+${CP_LN} ${EXECrtma3d}/${exefile_name_cloud} ${pgm}
+${MPIRUN} ${pgm} > ${pgmout} 2>errfile
+export err=$?; err_chk
 
-# Run Processing lightning
-# copy the excutable file of processing NASA LaRC Cloud data
-  ${CP} ${EXECrtma3d}/${exefile_name_cloud}   ./rtma3d_process_cloud
+msg="JOB $job FOR $RUN HAS COMPLETED NORMALLY"
+postmsg "$jlogfile" "$msg"
 
-  runline="${MPIRUN}             ./rtma3d_process_cloud"
-  $runline >> ${pgmout} 2>errfile
-  export err=$?; err_chk
-
-  msg="JOB $job FOR $RUN HAS COMPLETED NORMALLY"
-  postmsg "$jlogfile" "$msg"
-
-  if [ -f ${DATA}/NASALaRCCloudInGSI.bufr ] ; then
-    cpreq ${DATA}/NASALaRCCloudInGSI.bufr ${COMINobsproc_rtma3d}/${RUN}.t${cyc}${subcyc}z.NASALaRCCloudInGSI.bufr
+targetfile="NASALaRCCloudInGSI.bufr"
+if [ -f ${DATA}/${targetfile} ] ; then
+  if [ "${envir}" == "esrl" ]; then #Jet
+    mv ${DATA}/${targetfile} ${COMINobsproc_rtma3d}/${tz_str}.${targetfile} #to save disk space
+    ${LN} -snf ${COMINobsproc_rtma3d}/${tz_str}.${targetfile} ${DATA}/${targetfile}
   else
-    msg="WARNING $pgm terminated normally but ${DATA}/NASALaRCCloudInGSI_bufr.bufr does NOT exist."
-    ${ECHO} "$msg"
-    postmsg "$jlogfile" "$msg"
-    exit 1
+    cpreq ${DATA}/${targetfile} ${COMINobsproc_rtma3d}/${RUN}.${tz_str}.${targetfile}
   fi
+else
+  msg="WARNING $pgm terminated normally but ${DATA}/${targetfile} does NOT exist."
+  ${ECHO} "$msg"
+  postmsg "$jlogfile" "$msg"
+  exit 1
+fi
 
 exit 0

--- a/scripts/exrtma3d_post.ksh
+++ b/scripts/exrtma3d_post.ksh
@@ -1,126 +1,54 @@
 #!/bin/ksh 
-
 set -x
-export OMP_NUM_THREADS=1
-
+check_if_defined() { #usage: check_if_defined "var1_name" "var2_name" ...
+  for str in "$@"; do
+    eval "path=\${$str}"
+    if [ -z "${path}" ]; then
+      ${ECHO} "ERROR: \$${str} is not defined"; exit 1
+    fi
+  done
+}
 # Make sure we are using GMT time zone for time computations
 export TZ="GMT"
+#currently, UPP needs its own verion of CRTM
+  #the post task in the xml file will define $FIXcrtm
+export CORE=RAPRRTMA #submodelname='RTMA' to update 10m wind
 
-#------------------------------------------------------------------#
-#
-# set up of Analysis Time 
-#
-# ANLS_TIME=${PDY}' '${cyc}
-ANLS_TIME=${ANLS_TIME:-"${PDY} ${cyc}"}            # YYYYMMDD HH
-echo $PDY $cyc $subcyc
-# cyc_intvl="60 minutes"       # <-- cycle interval (minute)
-FCST_TIME="00"                 # <-- forecast time (hour) to provide fgs for rtma
-
-# For RTMA there is no forecast, so START_TIME is ANLS_TIME
-START_TIME=$ANLS_TIME
-
-# Make sure START_TIME is defined and in the correct format (YYYYMMDD HH)
-if [ ! "${START_TIME}" ]; then
-  ${ECHO} "ERROR: \$START_TIME is not defined!"
+# Check to make sure the executable exists
+if [ ! -s ${EXECrtma3d}/${exefile_name_post} ]; then
+  ${ECHO} "ERROR: ${EXECrtma3d}/${exefile_name_post} does not exist"
   exit 1
+fi
+
+check_if_defined "POST_NAME" "FCST_TIME" "WRFOUT_DIR" "PDY" "cyc" "subcyc"
+# Check to make sure that WRFOUT_DIR exists
+if [ ! -s "${WRFOUT_DIR}/wrf_inout" } ]; then
+  ${ECHO} "ERROR: $WRFOUT_DIR/wrf_inout, does not exist."
+  exit 1
+fi
+
+if [[ "${subcyc}" == "-1" ]]; then #it's hourly run
+  tz_str=t${cyc}z
+  SUBH_TIME=00
 else
-  if [ `${ECHO} "${START_TIME}" | ${AWK} '/^[[:digit:]]{10}$/'` ]; then
-    START_TIME=`${ECHO} "${START_TIME}" | ${SED} 's/\([[:digit:]]\{2\}\)$/ \1/'`
-  elif [ ! "`${ECHO} "${START_TIME}" | ${AWK} '/^[[:digit:]]{8}[[:blank:]]{1}[[:digit:]]{2}$/'`" ]; then
-    ${ECHO} "ERROR: start time, '${START_TIME}', is not in 'yyyymmddhh' or 'yyyymmdd hh' format"
-    exit 1
-  fi
-  START_TIME=`${DATE} -d "${START_TIME} ${subcyc} minutes"`
+  tz_str=t${cyc}${subcyc}z
+  SUBH_TIME=${subcyc}
 fi
+START_TIME=`${DATE} -d "${PDY} ${cyc} ${SUBH_TIME} minutes"`
 
-ANLS_CYC_TIME=`${DATE} --date="${START_TIME}  0 hour " +"%Y%m%d%H%M"`
-FCST_INI_TIME=`${DATE} --date="${START_TIME} -${FCST_TIME} hour " +"%Y%m%d%H%M"`
-export WGRIB2=/gpfs/dell1/nco/ops/nwprod/grib_util.v1.1.0/exec/wgrib2
-# Compute date & time components for the analysis time
-YYYYMMDDHHMU=`${DATE} +"%Y%m%d%H%M" -d "${START_TIME}"`
-YYYYMMDDHH=`${DATE} +"%Y%m%d%H" -d "${START_TIME}"`
-YYYYMMDD=`${DATE} +"%Y%m%d" -d "${START_TIME}"`
-YYYY=`${DATE} +"%Y" -d "${START_TIME}"`
-MM=`${DATE} +"%m" -d "${START_TIME}"`
-DD=`${DATE} +"%d" -d "${START_TIME}"`
-HH=`${DATE} +"%H" -d "${START_TIME}"`
-mm=`${DATE} +"%M" -d "${START_TIME}"`
-JJJ=`${DATE} +"%j" -d "${START_TIME}"`
-time_str=`${DATE} "+%Y-%m-%d_%H_%M_%S" -d "${START_TIME}"`
-${ECHO} " time_str = ${time_str}"
-time_run=${time_str}
+#----- enter working directory -------
+cd ${DATA}
+${ECHO} "enter working directory:${DATA}"
 
-HH_fcstinit=`${ECHO} ${FCST_INI_TIME} | cut -c9-10 `
-#------------------------------------------------------------------#
-
-export DATAHOME=$DATA
-export MODEL="RAP"
-
-export DATAWRFHOME=${COMOUTgsi_rtma3d:-"$COMIN"}
-export DATAWRFFILE=${ANLrtma3d_FNAME:-"${RUN}.t${cyc}${subcyc}z.anl.wrf_inout.nc"}
-
-##########################################################################
-
-# Check to make sure the post executable exists
-if [ ! -x ${EXECrtma3d}/${exefile_name_post} ]; then
-  ${ECHO} "ERROR: ${EXECrtma3d}/${exefile_name_post} does not exist, or is not executable"
-  exit 1
-fi
-
-# Check to make sure that the DATAHOME exists
-if [ ! ${DATAHOME} ]; then
-  ${ECHO} "ERROR: DATAHOME, \$DATAHOME, is not defined"
-  exit 1
-fi
-
-# Check to make sure that the DATAWRFHOME is defined
-if [ ! ${DATAWRFHOME} ]; then
-  ${ECHO} "ERROR: DATAWRFHOME, \$DATAWRFHOME, is not defined."
-  exit 1
-fi
-
-# Check to make sure that the DATAHOME exists
-if [ ! -d ${DATAWRFHOME} ]; then
-  ${ECHO} "ERROR: $DATAWRFHOME, does not exist."
-  exit 1
-fi
-
-if [ ! -f ${DATAWRFHOME}/${DATAWRFFILE} ]; then
-  ${ECHO} "ERROR: $DATAWRFHOME/${DATAWRFFILE}, does not exist."
-  exit 1
-fi
-
-
-
-# Print out times
-${ECHO} "   START TIME = "`${DATE} +%Y%m%d%H%M -d "${START_TIME}"`
-${ECHO} "    FCST_TIME = ${FCST_TIME}"
-
-export STARTTIME_STR=`${DATE} +%Y%m%d%H%M -d "${START_TIME}"`
-
-# Set up the work directory and cd into it
-workdir=${DATAHOME}/${FCST_TIME}
+# Set up temporary work directory and cd into it
+workdir=${DATA}/${tz_str}
 ${RM} -rf ${workdir}
 ${MKDIR} -p ${workdir}
 cd ${workdir}
 
-#
-# Set up some constants for UPP namlist itag
-#
+# Set up some constants
 export XLFRTEOPTS="unit_vars=yes"
-
-if [ "${MODEL}" == "RAP" ]; then
-  export CORE=RAPRRTMA
-elif [ "${MODEL}" == "WRF-RR NMM" ]; then
-  export CORE=NMM
-fi
-
-# export tmmark=tm00
-# export tmmark=GrbF00
-# export tmmark=GrbF${FCST_TIME}
-export RSTFNL=${workdir}/
-
-export CORE=RAPRRTMA
+export MP_SHARED_MEMORY=yes
 export SPLNUM=47
 export SPL=2.,5.,7.,10.,20.,30.\
 ,50.,70.,75.,100.,125.,150.,175.,200.,225.\
@@ -129,13 +57,11 @@ export SPL=2.,5.,7.,10.,20.,30.\
 ,675.,700.,725.,750.,775.,800.,825.,850.\
 ,875.,900.,925.,950.,975.,1000.,1013.2
 
-# export VALIDTIMEUNITS=00
-
-timestr=`${DATE} +%Y-%m-%d_%H_%M_%S -d "${START_TIME}  ${FCST_TIME} hours"`
-timestr2=`${DATE} +%Y-%m-%d_%H:%M:%S -d "${START_TIME}  ${FCST_TIME} hours"`
+timestr=`${DATE} +%Y-%m-%d_%H_%M_%S -d "${START_TIME}"`
+timestr2=`${DATE} +%Y-%m-%d_%H:%M:%S -d "${START_TIME}"`
 
 ${CAT} > itag <<EOF
-${DATAWRFHOME}/${DATAWRFFILE}
+${WRFOUT_DIR}/wrf_inout
 netcdf
 grib2
 ${timestr2}
@@ -145,151 +71,114 @@ ${SPL}
 ${VALIDTIMEUNITS}
 EOF
 
-${RM} -f fort.*
-${RM} -f post_avblflds.xml params_grib2_tbl_new postcntrl.xml postxconfig-NT.txt eta_micro_lookup.dat
-${RM} -f WRF???.GrbF??
-# set up the namelist/control/config input files
-# hrrr"x": means experimental testing.
-# cp -p ${PARMupp}/hrrr_post_avblflds.xml          post_avblflds.xml
-  cp -p ${PARMupp}/post_avblflds_raphrrr.xml       post_avblflds.xml
-# cp -p ${PARMupp}/hrrr_params_grib2_tbl_new       params_grib2_tbl_new
-  cp -p ${PARMupp}/params_grib2_tbl_new_raphrrr    params_grib2_tbl_new
-# cp -p ${PARMupp}/hrrr_postcntrl.xml              postcntrl.xml
-# cp -p ${PARMupp}/postcntrl_hrrr.xml              postcntrl.xml
-  cp -p ${PARMupp}/postcntrl_hrrrx.xml             postcntrl.xml
-
-# if [ -f ${PARMupp}/hrrr_postxconfig-NT.txt ] ; then
-#   cp -p ${PARMupp}/hrrr_postxconfig-NT.txt       postxconfig-NT.txt
-if [ -f ${PARMupp}/postxconfig-NT-hrrrx.txt ] ; then
-  cp -p ${PARMupp}/postxconfig-NT-hrrrx.txt        postxconfig-NT.txt
+if [ "${envir}" == "esrl" ]; then #Jet
+  CP_LN="${LN} -sf"
 else
-  echo " Warning: No postxconfig-NT.txt file. UPP Abort!"
-  exit 1
+  CP_LN=${CP}
 fi
+#link/copy parameter files
+${CP_LN} ${PARMupp}/post_avblflds.xml post_avblflds.xml
+${CP_LN} ${PARMupp}/params_grib2_tbl_new params_grib2_tbl_new
+${CP_LN} ${PARMupp}/postcntrl.xml postcntrl.xml
+${CP_LN} ${PARMupp}/postxconfig-NT.txt postxconfig-NT.txt  ##postcntrl_subh.xml postxconfig_subh-NT.txt??
+${CP_LN} ${PARMupp}/gtg.config.raphrrr gtg.config
 
-if [ "${MODEL}" == "RAP" ]; then
-  cp -p ${PARMupp}/rap_micro_lookup.dat      eta_micro_lookup.dat
-elif [ "${MODEL}" == "WRF-RR NMM" ]; then
-  cp -p ${PARMupp}/nam_micro_lookup.dat      eta_micro_lookup.dat
-fi
+${CP_LN} ${FIXupp}/ETAMPNEW_DATA eta_micro_lookup.dat
 
-################################################################################
-# ln -s ${FIXcrtm}/EmisCoeff/Big_Endian/Nalli.EK-PDF.W_W-RefInd.EmisCoeff.bin EmisCoeff.bin
-################################################################################
-
-for what in "amsre_aqua" "imgr_g11" "imgr_g12" "imgr_g13" \
-    "imgr_g15" "imgr_mt1r" "imgr_mt2" "seviri_m10" \
-    "ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16" \
-    "ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" \
-    "tmi_trmm" "v.seviri_m10" "imgr_insat3d" ; do
-    ln -s "$FIXcrtm/$what.TauCoeff.bin" .
-    ln -s "$FIXcrtm/$what.SpcCoeff.bin" .
+#link CRTM coefficients
+for what in "imgr_g11" "imgr_g12" "imgr_g13" "imgr_g15" "imgr_mt1r" "imgr_mt2" \
+     "amsre_aqua" "tmi_trmm" "ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16"  \
+     "ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" "seviri_m10" "ssmi_f10"   \
+     "v.seviri_m10" "imgr_insat3d" "ssmi_f11"; do
+    ln -s "${FIXcrtm}/${what}.TauCoeff.bin" .
+    ln -s "${FIXcrtm}/${what}.SpcCoeff.bin" .
 done
 
-for what in 'Aerosol' 'Cloud' ; do
-    ln -s "$FIXcrtm/${what}Coeff.bin" .
+ln -s ${FIXcrtm}/CloudCoeff.bin .
+ln -s ${FIXcrtm}/AerosolCoeff.bin .
+for what in  ${FIXcrtm}/*Emis* ; do
+    ln -s ${what} .
 done
 
-for what in  $FIXcrtm/*Emis* ; do
-    ln -s $what .
-done
-
-#=============================================================================#
-#
-# Run unipost
-#
-pgm=${RUN}_post
+#---- Run unipost
+export pgm="rtma3d_post"
 . prep_step
-
 startmsg
 msg="***********************************************************"
 postmsg "$jlogfile" "$msg"
-msg="  begin Uni-Post step for 3DRTMA GSI Analysis"
+msg="  begin post-processing"
 postmsg "$jlogfile" "$msg"
 msg="***********************************************************"
 postmsg "$jlogfile" "$msg"
 
+${CP_LN} ${EXECrtma3d}/${exefile_name_post} ${pgm}
+${MPIRUN} ${pgm} <itag > ${pgmout} 2>errfile
+export err=$?; err_chk
 
-#copy executable to running directory
-${CP} ${EXECrtma3d}/${exefile_name_post} ./rtma3d_wrfpost
-
- runline="${MPIRUN}         ./rtma3d_wrfpost"
-$runline < itag > ${pgmout} 2>errfile
-export err=$? ; err_chk
-
-if [ ${err} -ne 0 ]; then
-  ${ECHO} "rtma3d_wrfpost crashed!  Exit status=${err}"
-  exit ${err}
+if [ "${envir}" == "esrl" ]; then #Jet
+  wrfprsfile="wrfprs_${POST_NAME}_${FCST_TIME}.grib2"
+  wrfnatfile="wrfnat_${POST_NAME}_${FCST_TIME}.grib2"
+  wrftwofile="wrftwo_${POST_NAME}_${FCST_TIME}.grib2"
+  wrfmslfile="wrfmsl_${POST_NAME}_${FCST_TIME}.grib2"
+else
+  wrfprsfile="wrfsubhprs.grib2"
+  wrfnatfile="wrfsubhnat.grib2"
+  wrftwofile="wrfsubhspl.grib2"
+  wrfmslfile="wrfsubhmsl.grib2"
 fi
-
-# Linking GrbF{HH} to GrbF00 (esp. for firstguess which is from WRF forecast)
-GrbFiles=`ls WRF???.GrbF??`
-for i in ${GrbFiles}
-do
-  i_fname=`echo "$i" | cut -d '.' -f 1`
-  i_extname=`echo "$i" | cut -d '.' -f 2`
-  if [[ "${i_extname}" != "GrbF${FCST_TIME}" ]]
-  then
-    ln -sf $i    ./${i_fname}.GrbF${FCST_TIME}
-  fi
-done
-
 # Append entire wrftwo to wrfprs
-${CAT} ${workdir}/WRFPRS.GrbF${FCST_TIME}     ${workdir}/WRFTWO.GrbF${FCST_TIME} > ${workdir}/WRFPRS.GrbF${FCST_TIME}.new
-${MV}  ${workdir}/WRFPRS.GrbF${FCST_TIME}.new ${workdir}/wrfsubhprs.grib2
+${CAT} ${workdir}/WRFPRS.GrbF${FCST_TIME}  ${workdir}/WRFTWO.GrbF${FCST_TIME} > ${workdir}/WRFPRS.GrbF${FCST_TIME}.new
+${MV}  ${workdir}/WRFPRS.GrbF${FCST_TIME}.new ${workdir}/${wrfprsfile}
 
 # Append entire wrftwo to wrfnat
-${CAT} ${workdir}/WRFNAT.GrbF${FCST_TIME}     ${workdir}/WRFTWO.GrbF${FCST_TIME} > ${workdir}/WRFNAT.GrbF${FCST_TIME}.new
-${MV}  ${workdir}/WRFNAT.GrbF${FCST_TIME}.new ${workdir}/wrfsubhnat.grib2
+${CAT} ${workdir}/WRFNAT.GrbF${FCST_TIME}  ${workdir}/WRFTWO.GrbF${FCST_TIME} > ${workdir}/WRFNAT.GrbF${FCST_TIME}.new
+${MV}  ${workdir}/WRFNAT.GrbF${FCST_TIME}.new ${workdir}/${wrfnatfile}
 
-${CP}  ${workdir}/WRFTWO.GrbF${FCST_TIME}     ${workdir}/wrfsubhspl.grib2
+${MV}  ${workdir}/WRFTWO.GrbF${FCST_TIME}     ${workdir}/${wrftwofile}
+${MV}  ${workdir}/WRFMSL.GrbF${FCST_TIME}     ${workdir}/${wrfmslfile}
 
 # Check to make sure all Post  output files were produced
-if [ ! -s "${workdir}/wrfsubhprs.grib2" ]; then
-  ${ECHO} "unipost crashed! wrfsubhprs.grib2 is missing"
+if [ ! -s "${workdir}/${wrfprsfile}" ]; then
+  ${ECHO} "unipost crashed! ${wrfprsfile} is missing"
   exit 1
 fi
-if [ ! -s "${workdir}/wrfsubhspl.grib2" ]; then
-  ${ECHO} "unipost crashed! wrfsubhspl.grib2 is missing"
+if [ ! -s "${workdir}/${wrftwofile}" ]; then
+  ${ECHO} "unipost crashed! ${wrftwofile} is missing"
   exit 1
 fi
-if [ ! -s "${workdir}/wrfsubhnat.grib2" ]; then
-  ${ECHO} "unipost crashed! wrfsubhnat.grib2 is missing"
+if [ ! -s "${workdir}/${wrfnatfile}" ]; then
+  ${ECHO} "unipost crashed! ${wrfnatfile} is missing"
   exit 1
 fi
 
-# transfer the output grib2 files to $COMOUTpost_rtma3d
+if [ "${envir}" == "esrl" ]; then #Jet expr runs
+  # Move the grib2 files one level up to postprd/
+  ${MV} ${workdir}/wrfprs_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}
+  ${MV} ${workdir}/wrftwo_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}
+  ${MV} ${workdir}/wrfnat_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}
+  ${MV} ${workdir}/wrfmsl_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}
+  ${RM} -rf ${workdir}/WRFPRS.GrbF${FCST_TIME}
+  ${RM} -rf ${workdir}/WRFNAT.GrbF${FCST_TIME}
 
-${WGRIB2} ${workdir}/wrfsubhprs.grib2 -set center 7 -grib ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfsubhprs.grib2
-${WGRIB2} ${workdir}/wrfsubhspl.grib2 -set center 7 -grib ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfsubhspl.grib2
-${WGRIB2} ${workdir}/wrfsubhnat.grib2 -set center 7 -grib ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfsubhnat.grib2
+  # Create softlinks for transfer
+  basetime=`${DATE} +%y%j%H%M -d "${START_TIME}"`
+  ln -s ${DATA}/wrfprs_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}/wrfprs_${basetime}${FCST_TIME}00
+  ln -s ${DATA}/wrftwo_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}/wrftwo_${basetime}${FCST_TIME}00
+  ln -s ${DATA}/wrfnat_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}/wrfnat_${basetime}${FCST_TIME}00
+  #ln -s ${DATA}/wrfmsl_${POST_NAME}_${FCST_TIME}.grib2 ${DATA}/wrfmsl_${basetime}${FCST_TIME}00
 
+else #wcoss
+  # transfer the output grib2 files to $COMOUTpost_rtma3d
+  ${WGRIB2} ${workdir}/wrfsubhprs.grib2 -set center 7 -grib ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfsubhprs.grib2
+  ${WGRIB2} ${workdir}/wrfsubhspl.grib2 -set center 7 -grib ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfsubhspl.grib2
+  ${WGRIB2} ${workdir}/wrfsubhnat.grib2 -set center 7 -grib ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfsubhnat.grib2
 
-# softlinks with Julian date
-#basetime=`${DATE} +%y%j%H%M -d "${START_TIME}"`
-#${LN} -sf ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfprs_subhrconus_${FCST_TIME}.grib2 ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfprs_${basetime}${FCST_TIME}00
-#${LN} -sf ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrftwo_subhrconus_${FCST_TIME}.grib2 ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrftwo_${basetime}${FCST_TIME}00
-#${LN} -sf ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfnat_subhrconus_${FCST_TIME}.grib2 ${COMOUTpost_rtma3d}/${PROD_HEAD}.wrfnat_${basetime}${FCST_TIME}00
-
-#================================================================================#
-# The following data transferr is used in GSD old unipost script
-#  (Should be removed for NCO usage)
-# Move the output files to postprd under $COMOUTpost_rtma3d
-# ${MV} ${workdir}/wrfprs_subhrconus_${FCST_TIME}.grib2 ${DATAHOME}/wrfprs_subhrconus_${FCST_TIME}.grib2
-# ${MV} ${workdir}/wrftwo_subhrconus_${FCST_TIME}.grib2 ${DATAHOME}/wrftwo_subhrconus_${FCST_TIME}.grib2
-# ${MV} ${workdir}/wrfnat_subhrconus_${FCST_TIME}.grib2 ${DATAHOME}/wrfnat_subhrconus_${FCST_TIME}.grib2
-
-# ${RM} -rf ${workdir}
+  #${RM} -rf ${workdir}
   ${RM} -f  ${workdir}/wrfsubh???.grib2
   ${RM} -f  ${workdir}/WRF???.GrbF??
+fi
 
-# Create softlinks for transfer
-# basetime=`${DATE} +%y%j%H%M -d "${START_TIME}"`
-# ln -s ${DATAHOME}/wrfprs_subhrconus_${FCST_TIME}.grib2 ${DATAHOME}/wrfprs_${basetime}${FCST_TIME}00
-# ln -s ${DATAHOME}/wrftwo_subhrconus_${FCST_TIME}.grib2 ${DATAHOME}/wrftwo_${basetime}${FCST_TIME}00
-# ln -s ${DATAHOME}/wrfnat_subhrconus_${FCST_TIME}.grib2 ${DATAHOME}/wrfnat_${basetime}${FCST_TIME}00
-#================================================================================#
-
-${ECHO} "unipost completed at `${DATE}`"
+msg="JOB $job FOR $RUN HAS COMPLETED NORMALLY"
+postmsg "$jlogfile" "$msg"
 
 exit 0

--- a/scripts/exrtma3d_updatevars.ksh
+++ b/scripts/exrtma3d_updatevars.ksh
@@ -24,25 +24,14 @@ if [ "${envir}" == "esrl" ]; then
 fi
 
 # make sure executable exists
-if [ ! -f ${EXECrtma3d}/${exefile_name_updatevars_wrf} ]; then
-  ${ECHO} "ERROR: executable '${EXECrtma3d}/${exefile_name_updatevars_wrf}' does not exist!"
+if [ ! -f ${EXECrtma3d}/${exefile_name_updatevars} ]; then
+  ${ECHO} "ERROR: executable '${EXECrtma3d}/${exefile_name_updatevars}' does not exist!"
   exit 1
 fi
-if [ ! -f ${EXECrtma3d}/${exefile_name_updatevars_ncfields} ]; then
-  ${ECHO} "ERROR: executable '${EXECrtma3d}/${exefile_name_updatevars_ncfields}' does not exist!"
-  exit 1
-fi
-if [ ! -f ${EXECrtma3d}/${exefile_name_updatevars_ndown} ]; then
-  ${ECHO} "ERROR: executable '${EXECrtma3d}/${exefile_name_updatevars_ndown}' does not exist!"
-  exit 1
-fi
-
-
-
 
 # Check to make sure required directory defined and existed
-check_if_defined "FCST_LENGTH" "DATA_GSIANL" "FIXwrf" "PDY" "cyc" "subcyc"
-check_dirs_exist "DATA_GSIANL" "FIXwrf"
+check_if_defined "FCST_LENGTH" "GSIRUN_DIR" "FIXwrf" "PDY" "cyc" "subcyc"
+check_dirs_exist "GSIRUN_DIR" "FIXwrf"
 
 # Initialize an array of WRF input dat files that need to be linked
 set -A WRF_DAT_FILES ${FIXwrf}/run/LANDUSE.TBL          \
@@ -112,31 +101,21 @@ time_str2=`${DATE} "+%Y-%m-%d_%H_00_00" -d "${START_TIME}"`
 END_TIME=`${DATE} -d "${START_TIME}  ${FCST_LENGTH} seconds"`
 
 #----- enter working directory -------
-cd ${DATAHOME}
-${ECHO} "enter working directory:${DATAHOME}"
+cd ${DATA}
+${ECHO} "enter working directory:${DATA}"
 
-export WRF_NAMELIST=${DATAHOME}/namelist.input
+export WRF_NAMELIST=${DATA}/namelist.input
 ${CP} ${PARMwrf}/wrf.nl ${WRF_NAMELIST}
 
 # Check to make sure the wrfinput_d01 file exists
-#if [ -r ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
-#  ${ECHO} " Initial condition ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} "
-#  ${LN} -s ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} wrfinput_d01
-#   ${CP} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} wrfinput_d01
-#else
-#  ${ECHO} "ERROR: ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} does not exist, or is not readable"
-#  exit 1
-#fi
-
-if [ -r ${DATAHOME}/wrf_inout ]; then
-${ECHO} " Initial condition ${DATAHOME}/wrf_inout "
-${LN} -s ${DATAHOME}/wrf_inout wrfinput_d01
-#${LN} -s /gpfs/dell2/emc/modeling/noscrub/Edward.Colon/wrf_inout wrfinput_d01
+if [ -r ${GSIRUN_DIR}/wrf_inout ]; then
+  ${ECHO} " Initial condition ${GSIRUN_DIR}/wrf_inout "
+  ${LN} -s ${GSIRUN_DIR}/wrf_inout wrfinput_d01
+  #${LN} -s ${GSIRUN_DIR}/wrf_inout wrfvar_output
 else
-  ${ECHO} "ERROR: ${DATAHOME}/wrf_inout does not exist, or is not readable"
+  ${ECHO} "ERROR: ${GSIRUN_DIR}/wrf_inout does not exist, or is not readable"
   exit 1
 fi
-
 
 # Make links to the WRF DAT files
 for file in ${WRF_DAT_FILES[@]}; do
@@ -156,20 +135,6 @@ end_day=`${DATE} +%d -d "${END_TIME}"`
 end_hour=`${DATE} +%H -d "${END_TIME}"`
 end_minute=`${DATE} +%M -d "${END_TIME}"`
 end_second=`${DATE} +%S -d "${END_TIME}"`
-
-#start_year=2020
-#start_month=01
-#start_day=22
-#start_hour=16
-#start_minute=00
-#start_second=00
-#end_year=2020
-#end_month=01
-#end_day=22
-#end_hour=16
-#end_minute=00
-#end_second=20
-
 
 # Compute number of days and hours for the run
 (( run_days = 0 ))
@@ -206,8 +171,6 @@ ${SED} -i "\
    s/\(${end}_${minute}\)${equal}[[:digit:]]\{2\}/\1 = ${end_minute}/;    \
    s/\(${end}_${second}\)${equal}[[:digit:]]\{2\}/\1 = ${end_second}/;    \
 " ${WRF_NAMELIST}
-
-chmod 755 ${WRF_NAMELIST}
 
 # Move existing rsl files to a subdir if there are any
 ${ECHO} "Checking for pre-existing rsl files"
@@ -254,30 +217,39 @@ if [ ! -e "wrfout_d01_${time_str}" ]; then
   exit 1
 fi 
 
-${LN} -s wrfout_d01_${time_str} wrfout_d01
-${CP_LN} ${EXECrtma3d}/${exefile_name_update_ncfields} .
-
 # Output successful so write status to log
 ${ECHO} "Assemble Reflectivity fields back into wrf_inout"
+if [ "${envir}" == "esrl" ]; then #Jet
+  #${NCKS} -A -H -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM,U10,V10 wrfout_d01_${time_str} ${GSIRUN_DIR}/wrf_inout
+  ${NCKS} -A -H -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM wrfout_d01_${time_str} ${GSIRUN_DIR}/wrf_inout
+else
+  if [ ! -f ${EXECrtma3d}/${exefile_name_updatevars_ncfields} ]; then
+    ${ECHO} "ERROR: executable '${EXECrtma3d}/${exefile_name_updatevars_ncfields}' does not exist!"
+    exit 1
+  fi
+  ${CP_LN} ${EXECrtma3d}/${exefile_name_update_ncfields} .
+  ${LN} -s wrfout_d01_${time_str} wrfout_d01
+  ${exefile_name_update_ncfields} wrfout_d01 wrf_inout 
+  export err=$?; err_chk
 
-#${NCKS} -A -H -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM,U10,V10 wrfout_d01_${time_str} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} 
-#${NCKS} -A -H -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM wrfout_d01_${time_str} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} 
+  if [ -f ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
+    ${ECHO} "Erasing the GSI generated analysis file to be replaced by modified analysis."
+    ${RM} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+  fi
 
-${exefile_name_update_ncfields} wrfout_d01 wrf_inout 
-export err=$?; err_chk
-
-if [ -f ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
-  ${ECHO} "Erasing the GSI generated analysis file to be replaced by modified analysis."
-  ${RM} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+  ${CP_LN} -p wrf_inout ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
 fi
-
-${CP_LN} -p wrf_inout ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
 
 ${ECHO} "update_vars.ksh completed successfully at `${DATE}`"
 
 # Saving some files
 ${CP} -p namelist.input  ${COMOUTwrf_rtma3d}/namelist.input_${cycle_str}
 
+if [ "${envir}" == "esrl" ]; then #Jet
+  ${RM} -f ${DATA}/sig*
+  ${RM} -f ${DATA}/obs*
+  ${RM} -f ${DATA}/pe*
+fi
 
 msg="JOB $job FOR $RUN HAS COMPLETED NORMALLY"
 postmsg "$jlogfile" "$msg"


### PR DESCRIPTION
This PR is to resolve the remain differences between EMC and GSL realtime runs (mainly those under scripts/). The goal is to gradually reach one single copy of 3DRTMA workflow working for both subhourly and hourly runs, both operational and experimental runs, both conus and AK runs.

A few Notes about changes:
1. Define COMINhrrrdas in the xml file (or through environmental variables), not in the JJOB script
2. Added the environmental variable "EnsWgt" to facilitate a easy control of ensemble weight, needs to define it in the xml file
    in the gsianl.ksh scripts : `beta1_inv=$(( 1 - $EnsWgt  ))`
3. some scripts in the develop branch still come from legacy HRRRv3 system. They get updated with current GSL 3DRTMA runs.
4. Still some minor differences in the naming of post grib files due to some legacy plotting/verification code. But it was handled well using the "envir" variable:
     `if [ "${envir}" == "esrl" ]; then #Jet`   or ` if [ "${envir}" != "esrl" ]; then #WCOSS`
5. GSIANL will automatcially decide whether to run GSI twice, i.e. when the "${GSIANL_RES}" == "12km". This is used by 3DRTMA_AK
5. GSIANL needs the following enviromental variables:
    ${AIRCRAFT_REJECT} ${SFCOBS_USELIST}  ${SFCOBS_PROVIDER}
    ${OBS_DIR} ${ENKF_FCST} ${COMINhrrrdas} ${HRRRDAS_SMALL} 
    ${HRRRDAS_BEC} ${GSIANL_RES} ${EnsWgt}
6. An example xml file can be found here:
        https://github.com/NOAA-EMC/NOAA_3drtma/blob/jet/3drtma_dev1/xml/RTMA_3D.xml

