### PR TITLE
unify AK and conus runs on Jet

### DIFF
--- a/parm/wrf/wrf.nl_AK
+++ b/parm/wrf/wrf.nl_AK
@@ -1,0 +1,225 @@
+ &time_control
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2007,
+ start_month                         = 04,
+ start_day                           = 12,
+ start_hour                          = 00,
+ start_minute                        = 00,
+ start_second                        = 00,
+ end_year                            = 2007,
+ end_month                           = 04,
+ end_day                             = 12,
+ end_hour                            = 06,
+ end_minute                          = 00,
+ end_second                          = 00,
+ interval_seconds                    = 10800,
+ input_from_file                     = .true.,
+ history_interval                    = 60,
+ frames_per_outfile                  = 1,
+ cycling                             = .true.,
+ restart                             = .false.,
+ restart_interval                    = 5000,
+ WRITE_INPUT                         = .false.,
+ INPUTOUT_INTERVAL                   = 60,
+ input_outname                       = "wrfinput_out_d<domain>_<date>"
+ io_form_history                     = 11 
+ io_form_restart                     = 11
+ io_form_input                       = 11
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ diag_print                          = 1
+ gsd_diagnostics                     = 1
+ output_diagnostics                  = 1
+ diag_int                            = 15
+ wind_int                            = 5
+ nocolons                            = .true.
+ ncd_nofill                          = .true.
+ /
+
+&dfi_control
+ dfi_opt                             = 0,
+ dfi_nfilter                         = 7,
+ dfi_write_filtered_input            = F,
+ dfi_cutoff_seconds                  = 3600,
+/
+
+ &domains
+ time_step                           = 20, 
+ time_step_dfi                       = 20,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 1,
+ s_we                                = 1,     1,     1,
+ e_we                                = 1300,    112,   94,
+ s_sn                                = 1,     1,     1,
+ e_sn                                = 920,    97,    91,
+ s_vert                              = 1,     1,     1,
+ e_vert                              = 51,    28,    28,
+ num_metgrid_levels                  = 51, 
+ num_metgrid_soil_levels             = 9,
+ dx                                  = 3000.0, 10000,  3333,
+ dy                                  = 3000.0, 10000,  3333,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 1,     1,     2,
+ i_parent_start                      = 0,     31,    30,
+ j_parent_start                      = 0,     17,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ p_top_requested                     = 1500
+ interp_type                         = 1
+ rebalance                           = 0
+ hypsometric_opt                     = 2
+ lowest_lev_from_sfc                 = .false.
+ lagrange_order                      = 1
+ force_sfc_in_vinterp                = 1
+ zap_close_levels                    = 500
+ smooth_cg_topo                      = .true.
+ sfcp_to_sfcp                        = .false.
+ adjust_heights                      = .false.
+ eta_levels   =   1.0000, 0.9980, 0.9940, 0.9870, 0.9750, 0.9590,
+          0.9390, 0.9160, 0.8920, 0.8650, 0.8350, 0.8020, 0.7660,
+          0.7270, 0.6850, 0.6400, 0.5920, 0.5420, 0.4970, 0.4565,
+          0.4205, 0.3877, 0.3582, 0.3317, 0.3078, 0.2863, 0.2670,
+          0.2496, 0.2329, 0.2188, 0.2047, 0.1906, 0.1765, 0.1624,
+          0.1483, 0.1342, 0.1201, 0.1060, 0.0919, 0.0778, 0.0657,
+          0.0568, 0.0486, 0.0409, 0.0337, 0.0271, 0.0209, 0.0151,
+          0.0097, 0.0047, 0.0000,
+ use_adaptive_time_step              = .true.
+ step_to_output_time                 = .true.
+ target_cfl                          = 1.2
+ max_step_increase_pct               = 5
+ starting_time_step                  = 20
+ max_time_step                       = 20
+ min_time_step                       = 20
+ numtiles                            = 8
+ /
+
+ &physics
+ mp_physics                          = 28,     3,     3,
+ mp_tend_radar                       = 0,
+ do_radar_ref                        = 1,
+ ra_lw_physics                       = 4,     1,     1,
+ ra_sw_physics                       = 4,     1,     1,
+ ra_sw_eclipse                       = 1,
+ radt                                = 15,    30,    30,
+ swint_opt                           = 1,
+ CO2TF                               = 1,
+ sf_sfclay_physics                   = 5,     5,     1,
+ sf_surface_physics                  = 3,     3,     1,
+ sf_lake_physics                     = 0,     1,     1
+ bl_pbl_physics                      = 5,     5,     1,
+ bldt                                = 0,     0,     0,
+ bl_mynn_tkebudget                   = 0,
+ bl_mynn_tkeadvect                   = .false.,
+ bl_mynn_cloudpdf                    = 2,
+ bl_mynn_edmf                        = 1,
+ bl_mynn_edmf_mom                    = 1,
+ bl_mynn_edmf_tke                    = 0,
+ bl_mynn_mixlength                   = 2,
+ grav_settling                       = 0,
+ scalar_pblmix                       = 1,
+ cu_physics                          = 0,     1,     0,
+ cudt                                = 0,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ icloud_bl                           = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 9,
+ sf_urban_physics                    = 0,
+ mp_zero_out                         = 2,
+ mp_zero_out_thresh                  = 1.e-12,
+ use_aero_icbc                       = .true.
+ use_rap_aero_icbc                   = .true.
+ maxiens                             = 1,
+ maxens                              = 3,
+ maxens2                             = 3,
+ maxens3                             = 16,
+ ensdim                              = 144,
+ usemonalb                           = .true.,
+ rdlai2d                             = .true.,
+ num_land_cat                        = 20,
+ mosaic_lu                           = 1
+ mosaic_soil                         = 1
+ alb_sol                             = 1
+ fractional_seaice                   = 1,
+ seaice_threshold                    = 271.4
+ aer_opt                             = 3,
+ prec_acc_dt                         = 60.
+
+ tracer_pblmix                       = 0,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ zadvect_implicit                    = 1,
+ w_damping                           = 0,
+ diff_opt                            = 2,
+ km_opt                              = 4,
+ km_opt_dfi                          = 1,
+ diff_6th_opt                        = 2,
+ diff_6th_factor                     = 0.12,
+ diff_6th_slopeopt                   = 1,
+ diff_6th_thresh                     = 0.05,
+ moist_mix6_off                      = .true.,
+ chem_mix6_off                       = .true.,
+ tracer_mix6_off                     = .true.,
+ scalar_mix6_off                     = .true.,
+ tke_mix6_off                        = .true.,
+ damp_opt                            = 3,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.01,   0.01
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ SMDIV                               = 0.1,    0.1,    0.1,
+ EMDIV                               = 0.01,   0.01,   0.01,
+ EPSSM                               = 0.5,    0.1,    0.1
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      2,      2,
+ moist_adv_dfi_opt                   = 0,      1,     1,
+ scalar_adv_opt                      = 1,      2,      2,
+ TIME_STEP_SOUND                     = 4,      4,      4,
+ H_MOM_ADV_ORDER                     = 5,      5,      5,
+ V_MOM_ADV_ORDER                     = 5,      3,      3,
+ H_SCA_ADV_ORDER                     = 5,      5,      5,
+ V_SCA_ADV_ORDER                     = 5,      3,      3,
+ gwd_opt                             = 3,
+ hybrid_opt                          = 2
+ etac                                = 0.2
+
+ chem_adv_opt                        = 2,
+ tracer_opt                          = 0,
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 10,
+ spec_zone                           = 1,
+ relax_zone                          = 9,
+ specified                           = .false., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ open_xs                             = .true.,
+ open_xe                             = .true.,
+ open_ys                             = .true.,
+ open_ye                             = .true.,
+ /
+
+ &grib2
+ /
+
+ &logging
+ compute_tasks_silent                = .true. ! all compute ranks except 0 are silent
+ io_servers_silent                   = .true. ! all I/O server ranks are silent
+ stderr_logging                      = 0      ! disable output to stderr except for error messages
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 20,
+ nio_groups = 1,
+ /

--- a/scripts/exrtma3d_gsianl.ksh
+++ b/scripts/exrtma3d_gsianl.ksh
@@ -40,6 +40,11 @@ START_TIME=`${DATE} -d "${PDY} ${cyc} ${SUBH_TIME} minutes"`
 YYYYMMDDHH=`${DATE} +"%Y%m%d%H" -d "${START_TIME}"`
 YYYYMMDDHHMM=`${DATE} +"%Y%m%d%H%M" -d "${START_TIME}"`
 time_1hour_ago=`${DATE} -d "${START_TIME} 1 hour ago" +%Y%m%d%H`
+time_2hour_ago=`${DATE} -d "${START_TIME} 2 hour ago" +%Y%m%d%H`
+time_3hour_ago=`${DATE} -d "${START_TIME} 3 hour ago" +%Y%m%d%H`
+time_4hour_ago=`${DATE} -d "${START_TIME} 4 hour ago" +%Y%m%d%H`
+time_5hour_ago=`${DATE} -d "${START_TIME} 5 hour ago" +%Y%m%d%H`
+time_6hour_ago=`${DATE} -d "${START_TIME} 6 hour ago" +%Y%m%d%H`
 time_str=`${DATE} "+%Y-%m-%d_%H_%M_%S" -d "${START_TIME}"`
 time_str2=`${DATE} "+%Y-%m-%d_%H_00_00" -d "${START_TIME}"`
 
@@ -71,7 +76,28 @@ fi
 
 # Look for background field for GSI analysis
 if [ "${envir}" == "esrl" ]; then #Jet expr runs
-  GSIbackground=${HRRR_DIR}/${time_1hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground1=${HRRR_DIR}/${time_1hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground2=${HRRR_DIR}/${time_2hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground3=${HRRR_DIR}/${time_3hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground4=${HRRR_DIR}/${time_4hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground5=${HRRR_DIR}/${time_5hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground6=${HRRR_DIR}/${time_6hour_ago}/wrfprd/wrfout_d01_${time_str}
+  GSIbackground=${GSIbackground1}
+  if [ "${FG_FALLBACK}" == "YES" ]; then #fallback to old cycles if current first guess is not ready 
+    if [ -r ${GSIbackground1} ]; then
+      GSIbackground=${GSIbackground1}
+    elif [ -r ${GSIbackground2} ]; then
+      GSIbackground=${GSIbackground2}
+    elif [ -r ${GSIbackground3} ]; then
+      GSIbackground=${GSIbackground3}
+    elif [ -r ${GSIbackground4} ]; then
+      GSIbackground=${GSIbackground4}
+    elif [ -r ${GSIbackground5} ]; then
+      GSIbackground=${GSIbackground5}
+    elif [ -r ${GSIbackground6} ]; then
+      GSIbackground=${GSIbackground6}
+    fi
+  fi
 else
   GSIbackground=${BKG_DIR}/${FGSrtma3d_FNAME}
 fi

--- a/scripts/exrtma3d_obsprep_cloud.ksh
+++ b/scripts/exrtma3d_obsprep_cloud.ksh
@@ -42,7 +42,11 @@ if [ ! -s "./prepobs_prep.bufrtable" ]; then
 fi
 
 # WPS GEO_GRID Data
-${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc ./geo_em.d01.nc 
+if [ "${DOMAIN}" == "alaska" ]; then
+  ${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc_AK ./geo_em.d01.nc
+else
+  ${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc ./geo_em.d01.nc
+fi
 if [ ! -s "./geo_em.d01.nc" ]; then
   ${ECHO} "geo_em.d01.nc does not exist or not readable"
   exit 1 
@@ -65,14 +69,28 @@ if [ ! -s "NASA_LaRC_cloud.bufr" ]; then
 fi
 
 # Build the namelist on-the-fly
+if [ "${DOMAIN}" == "alaska" ]; then
 ${CAT} << EOF > namelist_nasalarc
 &SETUP
-  analysis_time = ${YYYYMMDDHH},
-  bufrfile='NASALaRCCloudInGSI.bufr',
-  npts_rad=3,
-  ioption = 2,
+analysis_time = ${YYYYMMDDHH},
+bufrfile='NASALaRCCloudInGSI.bufr',
+npts_rad=3,
+ioption = 2,
+boxlat0=60,61,63,66,68
+boxhalfy=4, 6, 8, 10, 12
+boxhalfx=4, 6, 8, 10, 12
 /
 EOF
+else
+${CAT} << EOF > namelist_nasalarc
+&SETUP
+analysis_time = ${YYYYMMDDHH},
+bufrfile='NASALaRCCloudInGSI.bufr',
+npts_rad=3,
+ioption = 2,
+/
+EOF
+fi
 
 # Run obs processor
 export pgm="rtma3d_process_cloud"

--- a/scripts/exrtma3d_obsprep_radar.ksh
+++ b/scripts/exrtma3d_obsprep_radar.ksh
@@ -80,7 +80,11 @@ if [ ! -s "./prepobs_prep.bufrtable" ]; then
 fi
 
 # WPS GEO_GRID Data
-${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc ./geo_em.d01.nc 
+if [ "${DOMAIN}" == "alaska" ]; then
+  ${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc_AK ./geo_em.d01.nc
+else
+  ${LN} -sf ${FIXwps}/hrrr_geo_em.d01.nc ./geo_em.d01.nc
+fi
 if [ ! -s "./geo_em.d01.nc" ]; then
   ${ECHO} "geo_em.d01.nc does not exist or not readable"
   exit 1 
@@ -97,6 +101,11 @@ ${ECHO} "YYYYMMDDHH: "${YYYYMMDDHH}
 
 # create mrms file list
 if [ "${envir}" == "esrl" ]; then #jet
+  if [ "${DOMAIN}" == "alaska" ]; then
+    middlename="MRMS_EXP_MergedReflectivityQC"
+  else
+    middlename="MRMS_MergedReflectivityQC"
+  fi
   for min in ${MM1} ${MM2} ${MM3}
   do
     ${ECHO} "Looking for data valid:"${YYYY}"-"${MM}"-"${DD}" "${HH}":"${min}
@@ -107,14 +116,14 @@ if [ "${envir}" == "esrl" ]; then #jet
       else
         ss=$s
       fi
-      nsslfile=${COMINradar}/${YYYY}${MM}${DD}-${HH}${min}${ss}.MRMS_MergedReflectivityQC_00.50_${YYYY}${MM}${DD}-${HH}${min}${ss}.grib2
+      nsslfile=${COMINradar}/${YYYY}${MM}${DD}-${HH}${min}${ss}.${middlename}_00.50_${YYYY}${MM}${DD}-${HH}${min}${ss}.grib2
       if [ -s $nsslfile ]; then
         echo 'Found '${nsslfile}
-        numgrib2=`ls ${COMINradar}/${YYYY}${MM}${DD}-${HH}${min}*.MRMS_MergedReflectivityQC_*_${YYYY}${MM}${DD}-${HH}${min}*.grib2 | wc -l`
+        numgrib2=`ls ${COMINradar}/${YYYY}${MM}${DD}-${HH}${min}*.${middlename}_*_${YYYY}${MM}${DD}-${HH}${min}*.grib2 | wc -l`
         echo 'Number of GRIB-2 files: '${numgrib2}
         if [ ${numgrib2} -ge 10 ] && [ ! -e filelist_mrms ]; then
-          ln -sf ${COMINradar}/${YYYY}${MM}${DD}-${HH}${min}*.MRMS_MergedReflectivityQC_*_${YYYY}${MM}${DD}-${HH}${min}*.grib2 . 
-          ls ${YYYY}${MM}${DD}-${HH}${min}*.MRMS_MergedReflectivityQC_*_${YYYY}${MM}${DD}-${HH}${min}*.grib2 > filelist_mrms
+          ln -sf ${COMINradar}/${YYYY}${MM}${DD}-${HH}${min}*.${middlename}_*_${YYYY}${MM}${DD}-${HH}${min}*.grib2 . 
+          ls ${YYYY}${MM}${DD}-${HH}${min}*.${middlename}_*_${YYYY}${MM}${DD}-${HH}${min}*.grib2 > filelist_mrms
           echo 'Creating links for SUBH: '${SUBH_TIME}
         fi
       fi

--- a/scripts/exrtma3d_updatevars.ksh
+++ b/scripts/exrtma3d_updatevars.ksh
@@ -105,7 +105,11 @@ cd ${DATA}
 ${ECHO} "enter working directory:${DATA}"
 
 export WRF_NAMELIST=${DATA}/namelist.input
-${CP} ${PARMwrf}/wrf.nl ${WRF_NAMELIST}
+if [ ${DOMAIN} == "alaska" ] ; then 
+  ${CP} ${PARMwrf}/wrf.nl_AK ${WRF_NAMELIST}
+else
+  ${CP} ${PARMwrf}/wrf.nl ${WRF_NAMELIST} 
+fi
 
 # Check to make sure the wrfinput_d01 file exists
 if [ -r ${GSIRUN_DIR}/wrf_inout ]; then
@@ -135,6 +139,13 @@ end_day=`${DATE} +%d -d "${END_TIME}"`
 end_hour=`${DATE} +%H -d "${END_TIME}"`
 end_minute=`${DATE} +%M -d "${END_TIME}"`
 end_second=`${DATE} +%S -d "${END_TIME}"`
+if [ ${DOMAIN} == "alaska" ] ; then 
+  mod3=$(( $start_hour % 3  ))
+  if [ $mod3 -eq 0 ]; then #don't run wrf since it will crash
+     echo "hour=$start_hour, skip wrf run"
+     exit 0
+  fi
+fi
 
 # Compute number of days and hours for the run
 (( run_days = 0 ))


### PR DESCRIPTION
Unify AK and conus runs on Jet.
A few notes:
1. set the environmental variable ${DOMAIN} to either 'conus' or 'alaska' to trigger conus or AK runs (borrowed from the feature/post-hwt-2 branch)
2. set the environmental variable ${FG_FALLBACK}  to 1 to activate the first-guess-fall-back functionality on Jet.
3. Need `parm/wrf/wrf.nl_AK ` (included in the repo) and
              `fix/wps/hrrr_geo_em.d01.nc_AK` (a local copy)

The changes were tested on Jet 4 realtime runs and all are good so far.