### PR TITLE
Temporarily remove logic for HRRRDAS dependency

### DIFF
--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -29,12 +29,12 @@ COMINhrrrdas=${COMINHRRRDAS}
 fi
 #START_TIME=`${DATE} -d "${PDY} ${cyc} ${SUBH_TIME} minutes"`
 START_TIME=`${DATE} -d "${PDY} ${cyc} ${subcyc} minutes"`
-START_TIME_HRRRDAS_CUTOFF=`${DATE} -d "${PDY} ${HRRRDAS_CUTOFF} ${subcyc} minutes"`
-if [ "${START_TIME} -le ${START_TIME_HRRRDAS_CUTOFF} ]; then
+#START_TIME_HRRRDAS_CUTOFF=`${DATE} -d "${PDY} ${cyc} ${HRRRDAS_CUTOFF} minutes"`
+#if [ ${START_TIME} -le ${START_TIME_HRRRDAS_CUTOFF} ]; then
 HRRRDAS_STATE=${HRRRDAS_BEC}
-else
-HRRRDAS_STATE=0
-fi
+#else
+#HRRRDAS_STATE=0
+#fi
 
 if [ ${HRRRDAS_STATE} -eq 0 ]; then
 EnsWgt=0.5

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -963,7 +963,7 @@
     </envar>
     <envar>
       <name>JJOB_HRRRDAS</name>
-     <value>&JJOB_HRRDAS;</value>
+     <value>&JJOB_HRRRDAS;</value>
     </envar>'>
 <!ENTITY ENVARS_UPDATEVARS
     '<envar>


### PR DESCRIPTION
The logic in the GSI ex-script does not work. After correcting the START_TIME_HRRRDAS_CUTOFF variable, it is unable to perform the comparison:

 0.006 + START_TIME='Thu Apr 17 19:00:00 UTC 2025'
 0.006 + /bin/date -d '20250417 19 32 minutes'
 0.009 + START_TIME_HRRRDAS_CUTOFF='Thu Apr 17 19:32:00 UTC 2025'
 0.009 + [ 'Thu Apr 17 19:00:00 UTC 2025' -le 'Thu Apr 17 19:32:00 UTC 2025' ]
/lfs/h2/emc/da/noscrub/matthew.t.morris/packages/rtma3d.v1.0.0/scripts/rtma3d/exrtma3d_gsianl.ksh[33]: [: Thu Apr 17 19:00:00 UTC 2025: arithmetic syntax error
 0.009 + HRRRDAS_STATE=0

Note also that you are always comparing against the top of the hour, when I think this should instead be based on the current time.

Temporarily set HRRRDAS_STATE=${HRRRDAS_BEC} while this can be thoroughly tested. Please test these changes before submitting the PR.