### PR TITLE
Resolution for late-arriving hrrrdas file within the gsianl ex-script

### DIFF
--- a/scripts/akrtma3d/exakrtma3d_gsianl.ksh
+++ b/scripts/akrtma3d/exakrtma3d_gsianl.ksh
@@ -651,7 +651,8 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
     ./current_bad_aircraft ./gsd_sfcobs_uselist.txt ./gsd_sfcobs_provider.txt ./stdout*
   ${CP} -p  misc_info.tgz                      ${COMOUTgsi_rtma3d}
   gzip ${COMOUTgsi_rtma3d}/diag_*
-
+  ${CP} -p  stdout 			       ${COMOUTgsi_rtma3d}
+  ${CP} -p  OUTPUT*                            ${COMOUTgsi_rtma3d}
   # extra backup (NOT necessary)
   #${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
   #${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -28,30 +28,6 @@ BKG_DIR=${DATAHOME_BK}
 COMINhrrrdas=${COMINHRRRDAS}
 fi
 START_TIME=`${DATE} -d "${PDY} ${cyc} ${subcyc} minutes"`
-
-CURRMIN=`$MDATE | cut -c11-12`
-CURRTIME=`$MDATE | cut -c1-10`
-STARTTIME=$PDY$cyc
-
-#If this is a catchup cycle, the HRRRDAS_STATE reverts to 1 assuming that the HRRRDAS files from previous
-#cycles are present.
-#Otherwise, the current minute past the hour is compared to hrrrdas cutoff.
-#Reverting to gdas forecast ensemble files if current min exceeds cutoff min.
-
-if [ ${CURRTIME} -gt ${STARTTIME} ]; then
-HRRRDAS_STATE=${HRRRDAS_BEC}
-elif [ ${CURRMIN} -le ${HRRRDAS_CUTOFF} ]; then
-  HRRRDAS_STATE=${HRRRDAS_BEC}
-else
-  HRRRDAS_STATE=0
-fi
-
-
-if [ ${HRRRDAS_STATE} -eq 0 ]; then
-EnsWgt=0.5
-else
-EnsWgt=0.9
-fi
 # Compute date & time components for the analysis time
 YYYYMMDDHH=`${DATE} +"%Y%m%d%H" -d "${START_TIME}"`
 YYYYMMDDHHMM=`${DATE} +"%Y%m%d%H%M" -d "${START_TIME}"`
@@ -168,7 +144,7 @@ else
   ${ECHO} "Warning: ${OBS_DIR}: satmar does not exist!"
 fi
 
-if [ "${envir}" = "lsf" ] || [ "${envir}" = "pbspro" ] && [ ${HRRRDAS_STATE} -eq 0 ] ; then #WCOSS
+#if [ "${envir}" = "lsf" ] || [ "${envir}" = "pbspro" ] && [ ${HRRRDAS_BEC} -eq 0 ] ; then #WCOSS
   # Set runtime and save directories
   export endianness=Big_Endian
 
@@ -203,11 +179,11 @@ if [ "${envir}" = "lsf" ] || [ "${envir}" = "pbspro" ] && [ ${HRRRDAS_STATE} -eq
   #   if not, set ifhyb=false
       cpreq ${UTILrtma3d_dev}/convert.sh .
   fi
-fi
+#fi
 
 
-if [ ${HRRRDAS_STATE} -eq 1 ]; then
-  ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_STATE}, so HRRRDAS will be used if available"
+if [ ${HRRRDAS_BEC} -eq 1 ]; then
+  ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_BEC}, so HRRRDAS will be used if available"
   #----------------------------------------------------
   # generate list of HRRRDAS members for ensemble covariances
   # Use 1-hr forecasts from the HRRRDAS cycling
@@ -230,7 +206,7 @@ if [ ${HRRRDAS_STATE} -eq 1 ]; then
    ((c = c + 1))
   done
 else
-  ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_STATE}, so HRRRDAS will NOT be used"
+  ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_BEC}, so HRRRDAS will NOT be used"
   ${TOUCH} filelist.hrrrdas #so as to avoid "no such file" error message
 fi
 
@@ -242,8 +218,9 @@ nummem=`more filelist03 | wc -l`
 nummem=$((nummem - 3 ))
 hrrrmem=`more filelist.hrrrdas | wc -l`
 hrrrmem=$((hrrrmem - 3 ))
-if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_STATE} -eq 1  ]]; then #if HRRRDAS BEC is available, use it as first choice
+if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC is available, use it as first choice
   echo "Do hybrid with HRRRDAS BEC"
+  EnsWgt=0.9
   nummem=${hrrrmem}
   cpreq filelist.hrrrdas filelist03
   ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
@@ -259,6 +236,7 @@ if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_STATE} -eq 1  ]]; then #if HRRRDAS BE
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses HRRRDAS BEC with n_ens=${nummem}" >> ${pgmout}
 elif [[ ${nummem} -eq 80 ]]; then
   echo "Do hybrid with GDAS directly"
+  EnsWgt=0.5
   ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
   beta1_inv=$(( 1 - $EnsWgt  ))
   ifhyb=.true.

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -30,12 +30,22 @@ fi
 START_TIME=`${DATE} -d "${PDY} ${cyc} ${subcyc} minutes"`
 
 CURRMIN=`$MDATE | cut -c11-12`
-#reverting to gdas if current min exceeds cutoff min
-if [ ${CURRMIN} -le ${HRRRDAS_CUTOFF} ]; then
+CURRTIME=`$MDATE | cut -c1-10`
+STARTTIME=$PDY$cyc
+
+#If this is a catchup cycle, the HRRRDAS_STATE reverts to 1 assuming that the HRRRDAS files from previous
+#cycles are present.
+#Otherwise, the current minute past the hour is compared to hrrrdas cutoff.
+#Reverting to gdas forecast ensemble files if current min exceeds cutoff min.
+
+if [ ${CURRTIME} -gt ${STARTTIME} ]; then
 HRRRDAS_STATE=${HRRRDAS_BEC}
+elif [ ${CURRMIN} -le ${HRRRDAS_CUTOFF} ]; then
+  HRRRDAS_STATE=${HRRRDAS_BEC}
 else
-HRRRDAS_STATE=0
+  HRRRDAS_STATE=0
 fi
+
 
 if [ ${HRRRDAS_STATE} -eq 0 ]; then
 EnsWgt=0.5

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -27,14 +27,15 @@ OBS_DIR=${DATAOBSHOME}
 BKG_DIR=${DATAHOME_BK}
 COMINhrrrdas=${COMINHRRRDAS}
 fi
-#START_TIME=`${DATE} -d "${PDY} ${cyc} ${SUBH_TIME} minutes"`
 START_TIME=`${DATE} -d "${PDY} ${cyc} ${subcyc} minutes"`
-#START_TIME_HRRRDAS_CUTOFF=`${DATE} -d "${PDY} ${cyc} ${HRRRDAS_CUTOFF} minutes"`
-#if [ ${START_TIME} -le ${START_TIME_HRRRDAS_CUTOFF} ]; then
+
+CURRMIN=`$MDATE | cut -c11-12`
+#reverting to gdas if current min exceeds cutoff min
+if [ ${CURRMIN} -le ${HRRRDAS_CUTOFF} ]; then
 HRRRDAS_STATE=${HRRRDAS_BEC}
-#else
-#HRRRDAS_STATE=0
-#fi
+else
+HRRRDAS_STATE=0
+fi
 
 if [ ${HRRRDAS_STATE} -eq 0 ]; then
 EnsWgt=0.5
@@ -689,9 +690,11 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
     ./current_bad_aircraft ./gsd_sfcobs_uselist.txt ./gsd_sfcobs_provider.txt ./stdout*
   ${CP} -p  misc_info.tgz                      ${COMOUTgsi_rtma3d}
   gzip ${COMOUTgsi_rtma3d}/diag_*
-  ${CP} -p filelist.hrrrdas 		               ${COMOUTgsi_rtma3d}
+  ${CP} -p filelist.hrrrdas 		       ${COMOUTgsi_rtma3d}
   ${CP} -p filelist03                          ${COMOUTgsi_rtma3d}
   ${CP} -p hybens_info                         ${COMOUTgsi_rtma3d}
+  ${CP} -p stdout                              ${COMOUTgsi_rtma3d}
+  ${CP} -p OUTPUT*                             ${COMOUTgsi_rtma3d}
   # extra backup (NOT necessary)
   #${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
   #${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}


### PR DESCRIPTION
Added a conditional block to the that addresses late-arriving hrrrdas files in scripts/rtma3d/exrtma3d_gsianl.ksh.  If the current min past the hour exceeds the hrrrdas cutoff, the script reverts to the use of gdas ensemble files. If a catchup cycle is involved, the code defaults to the use of hrrrdas ensemble files. 

NOTE: Since the development machine has reverted back to the 35+ minute obs arrival time, the HRRRDAS_CUTOFF in rtma3d_pbspro_conus.xml should be set to at least 45-50 minutes only on parallels run on WCOSS2 development. On WCOSS2 production, 32 minutes should remain a viable cutoff.