### PR TITLE
Put the step to concatenate the netcdf-format obs-diag files into a separate task

### DIFF
--- a/jobs/JRTMA3D_NCDIAG
+++ b/jobs/JRTMA3D_NCDIAG
@@ -1,0 +1,161 @@
+#!/bin/ksh
+
+# --- for debug --- #
+date
+export PS4=' $SECONDS + ' 
+set -x
+
+#######################################################
+# The following variable could be defined in the 
+# submission script (the ecf script *.sms, or ROCOTO *.xml),
+# if not, they will take the default values which is set 
+# for the NCO running enviroment
+#######################################################
+
+export RUN_ENVIR=${RUN_ENVIR:-nco}
+
+###################################
+# Specify NET and RUN Name and model
+####################################
+export NET=${NET:-rtma3d}
+export RUN=${RUN:-rtma3d}
+export model=${model:-rtma3d}
+
+##########################################################
+# obtain unique process id (pid)
+##########################################################
+export job=${job:-"${outid}.o$$"}
+export jobid=${jobid:-"${outid}.o$$"}
+export MPIRUN=${MPIRUN:-"mpirun"}
+
+export CNVGRIB=${CNVGRIB:-cnvgrib}
+export PDYm1=`$NDATE -24 ${PDY}${cyc} | cut -c 1-8`
+##########################################################
+# make temp/running directories
+##########################################################
+export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
+if [ -d $DATA ] ; then
+   ${ECHO} "$DATA exists, remove its content"
+   ${RM} -rf $DATA/*
+else
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
+fi
+cd $DATA
+
+#####################################################
+# Run setpdy and initialize PDY variables
+#    setpdy.sh needs the variables 
+#    $PDY and $cyc already defined in advance
+#####################################################
+#setpdy.sh
+#. ${DATA}/PDY
+  export cycle=${cycle:-t${cyc}z}
+  export pgmout=${pgmout:-"OUTPUT.${PDY}${cyc}.${jobid}"}
+
+####################################
+# Determine Job Output Name on System
+####################################
+export LOG_JJOB=${LOG_JJOB:-$COMROOT/logs/jlogfiles}
+export jlogfile=${jlogfile:-$LOG_JJOB/jlogfile.${jobid}}
+if [ ! -d ${LOG_JJOB} ] ; then
+   mkdir -p ${LOG_JJOB}
+fi
+if [ ! -d ${LOG_PGMOUT} ] ; then
+   mkdir -p ${LOG_PGMOUT}
+fi
+
+# specify the file head for the file names of the archived data files
+export PROD_HEAD=${PROD_HEAD:-"${NET}.t${cyc}z"}
+
+# Specify Execution Areas
+export HOMErtma3d=${HOMErtma3d:-$NWROOT/${NET}.${rtma_ver}}
+export EXECrtma3d=${EXECrtma3d:-$HOMErtma3d/exec}
+export FIXrtma3d=${FIXrtma3d:-$HOMErtma3d/fix/${NET}}
+export PARMrtma3d=${PARMrtma3d:-$HOMErtma3d/parm/${NET}}
+export USHrtma3d=${USHrtma3d:-$HOMErtma3d/ush/${NET}}
+export UTILrtma3d=${UTILrtma3d:-$HOMErtma3d/util/${NET}}
+
+# date and time for previous and next cycle
+export PDYHH="${PDY}${cyc}"
+export PDYHH_cycm1=$($NDATE -01  "${PDYHH}")
+export PDYHH_cycp1=$($NDATE +01  "${PDYHH}")
+export FGS_OPT=${FGS_OPT:-1}
+
+#################################################
+# Set up the INPUT and OUTPUT directories
+#################################################
+export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${NET}.${PDY}}
+export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${NET}.${PDY}}
+
+### 3DRTMA GSIANL Products (netcdf)
+export COMOUTgsi_rtma3d=${COMOUTgsi_rtma3d:-"${COMOUT}/gsiprd.${cycle}"}
+
+if [ ! -d "${COMIN}" ] ; then
+   mkdir -p $COMIN
+fi
+if [ ! -d "${COMOUT}" ] ; then
+   mkdir -p $COMOUT
+fi
+if [ ! -d "${COMOUTgsi_rtma3d}" ] ; then
+  ${MKDIR} -p ${COMOUTgsi_rtma3d}
+fi
+
+###########################################################
+#
+# The following variables are used in exrtma3d_ncdiag.ksh
+#
+###########################################################
+
+if [ "${envir}" != "esrl" ]; then #WCOSS
+
+#   Set the path to the top running/working directory for this analysis cycle:
+    export DATA_RUNDIR=${DATA_RUNDIR:-"${DATAROOT}/${envir}/${NET}.${PDY}${cyc}"}
+    if [ ! -d "${DATA_RUNDIR}" ] ; then
+        mkdir -p ${DATA_RUNDIR}
+    fi
+
+#   Set the path (DATAGSIHOME) to gsi running directory
+#       where the original netcdf format obs-diag files (not combined yet) are generated in GSI run
+    export DATAGSIHOME=${DATA_RUNDIR}/gsiprd
+    if [ ! -d "${DATAGSIHOME}" ] ; then
+       echo " Directory of GSI running data does NOT exist. Job abort!"
+       err_exit
+    fi
+
+    export DATAHOME=${DATA_RUNDIR}/ncdiagprd
+    if [ -L "${DATAHOME}" ] && [ -d "${DATAHOME}" ] ; then
+        ${RM} -rf ${DATAHOME}
+    fi
+    ${LN} -s  ${DATA}  ${DATAHOME}
+
+fi
+
+#   Set the path to the GSI static files
+    export FIXgsi=${FIXgsi:-"${FIXrtma3d}/gsi"}
+    export PARMgsi=${PARMgsi:-"${PARMrtma3d}/gsi"}
+
+##########################################################
+
+######################
+# Execute the script.
+######################
+${exSCR_NCDIAG:-$HOMErtma3d/scripts/ex${NET}_ncdiag.ksh}
+export err=$?; err_chk
+
+msg="$0 of $job completed normally"
+postmsg $jlogfile "$msg"
+
+if [ -e "${pgmout}" ] ; then
+   cat $pgmout
+   cpreq -p $pgmout ${LOG_PGMOUT}
+fi
+
+##############################
+# Remove the Temporary working directory
+##############################
+if [ "${KEEPDATA}" != YES ]; then
+   rm -rf $DATA
+fi
+
+date

--- a/jobs/launch.ksh
+++ b/jobs/launch.ksh
@@ -128,6 +128,11 @@ elif [ "${machine}" = "cray" ] ; then
       modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.gsi.${machine}"}
       source $modulefile_build
       ;;
+    *NCDIAG*)
+      modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.gsi.${machine}"}
+      source $modulefile_build
+      module load ncdiag/1.1.1
+      ;;
     *AUTOQC*)
       modulefile_build=${modulefile_build:-"${MODULEFILES}/${machine}/build/modulefile.build.gsi.${machine}"}
       source $modulefile_build

--- a/scripts/akrtma3d/exakrtma3d_anldump.ksh
+++ b/scripts/akrtma3d/exakrtma3d_anldump.ksh
@@ -159,9 +159,9 @@ postmsg "$jlogfile" "$msg"
         if [ $err -eq 0 ] ; then
            echo "           Successfully convert netcdf file to grib2 file for ${varname}."
            # save the analysis file (grib2) to $COMOUT
-           cp -p ./${grib2_fname}     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2     
+           cp -p ./${grib2_fname}     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2     
            # appending to a single grib2 file
-#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
         else
            echo "conversion of ${varname} in analysis from netcdf to grib2 failed."
         fi
@@ -213,9 +213,9 @@ postmsg "$jlogfile" "$msg"
         if [ $err -eq 0 ] ; then
            echo "           Successfully convert netcdf file to grib2 file for ${varname}."
            # save the analysis file (grib2) to $COMOUT
-           cp -p ./${grib2_fname}     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2     
+           cp -p ./${grib2_fname}     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2     
            # appending to a single grib2 file
-#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
         else
            echo "conversion of ${varname} in analysis from netcdf to grib2 failed."
         fi
@@ -267,9 +267,9 @@ postmsg "$jlogfile" "$msg"
         if [ $err -eq 0 ] ; then
            echo "           Successfully convert netcdf file to grib2 file for ${varname}."
            # save the analysis file (grib2) to $COMOUT
-           cp -p ./${grib2_fname}     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2     
+           cp -p ./${grib2_fname}     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2     
            # appending to a single grib2 file
-#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
         else
            echo "conversion of ${varname} in analysis from netcdf to grib2 failed."
         fi

--- a/scripts/akrtma3d/exakrtma3d_gsianl.ksh
+++ b/scripts/akrtma3d/exakrtma3d_gsianl.ksh
@@ -202,7 +202,7 @@ if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC 
   EnsWgt=0.9
   nummem=${hrrrmem}
   cpreq filelist.hrrrdas filelist03
-  ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
+  rm -f ./hybens_info
   beta1_inv=$(( 1 - $EnsWgt  ))
   ifhyb=.true.
   regional_ensemble_option=3
@@ -211,12 +211,14 @@ if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC 
   ens_fast_read=.true. 
   if [[ "${READIN_LOCALIZATION}" == "TRUE" ]] || [[ "${READIN_LOCALIZATION}" == "true" ]] ; then
      readin_localization=.true.
+     HYBENS_INFO=${PARMgsi}/hybens_info_hrrrdas
+     ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
   fi
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses HRRRDAS BEC with n_ens=${nummem}" >> ${pgmout}
 elif [[ ${nummem} -eq 80 ]]; then
   echo "Do hybrid with GDAS directly"
+  rm -f ./hybens_info
   EnsWgt=0.5
-  ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
   beta1_inv=$(( 1 - $EnsWgt  ))
   ifhyb=.true.
   regional_ensemble_option=1
@@ -225,6 +227,8 @@ elif [[ ${nummem} -eq 80 ]]; then
   ens_fast_read=.false. 
   if [[ "${READIN_LOCALIZATION}" == "TRUE" ]] || [[ "${READIN_LOCALIZATION}" == "true" ]] ; then
      readin_localization=.true.
+     HYBENS_INFO=${PARMgsi}/hybens_info
+     ${CP} ${PARMgsi}/hybens_info hybens_info
   fi
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses GDAS directly with n_ens=${nummem}" >> ${pgmout}
 else
@@ -239,13 +243,10 @@ else
 fi
 
 # copy the read-in localization file for hybrid envar analysis
-  HYBENS_INFO="hybens_info"
   if [[ "${readin_localization}" == ".true." ]] ; then
-     cp -p ${PARMgsi}/${HYBENS_INFO}  hybens_info
      
      # read in the weight for static background error at the surface level in hybrid envar run
      # the weight would be used to adjust the background error for howv/gust/vis
-     hybens_info_file="hybens_info"
      n=0
      set +x
      while read line_str
@@ -256,7 +257,7 @@ fi
            echo "Weight of static background error at level $n  --> $StaticWgt"
         fi
         let "n=n+1"
-     done < "$hybens_info_file"
+     done < ./hybens_info
      set -x
   else
      StaticWgt=${beta1_inv}
@@ -502,7 +503,12 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #WCOSS
 fi
 
 # option for netcdf-format obs diag file
-  L_NCDIAG=${L_NCDIAG:-".false."}     # false: no output of netcdf obsdiag, and do not combine them
+  RUN_NCDIAG=${RUN_NCDIAG:-"Yes"} # netcdf format obs-diag file (default: Yes)
+  if [[ ${RUN_NCDIAG} =~ [TtYy] ]] ; then
+     L_NCDIAG=".true."            # gsi dumps out netcdf obsdiag, run ncdiag to combine them
+  else
+     L_NCDIAG=".false."
+  fi
 
 #====  set GSI namelist options for analysis of HOWV/GUST/VIS ====#
 #  setup for howv
@@ -688,7 +694,6 @@ esac
 #  Collect diagnostic files for obs types (groups) below
 #  listall="hirs2_n14 msu_n14 sndr_g08 sndr_g11 sndr_g11 sndr_g12 sndr_g13 sndr_g08_prep sndr_g11_prep sndr_g12_prep sndr_g13_prep sndrd1_g11 sndrd2_g11 sndrd3_g11 sndrd4_g11 sndrd1_g12 sndrd2_g12 sndrd3_g12 sndrd4_g12 sndrd1_g13 sndrd2_g13 sndrd3_g13 sndrd4_g13 hirs3_n15 hirs3_n16 hirs3_n17 amsua_n15 amsua_n16 amsua_n17 amsub_n15 amsub_n16 amsub_n17 hsb_aqua airs_aqua amsua_aqua imgr_g08 imgr_g11 imgr_g12 pcp_ssmi_dmsp pcp_tmi_trmm conv sbuv2_n16 sbuv2_n17 sbuv2_n18 omi_aura ssmi_f13 ssmi_f14 ssmi_f15 hirs4_n18 hirs4_metop-a amsua_n18 amsua_metop-a mhs_n18 mhs_metop-a amsre_low_aqua amsre_mid_aqua amsre_hig_aqua ssmis_las_f16 ssmis_uas_f16 ssmis_img_f16 ssmis_env_f16 iasi_metop-a"
 
-
 #  binary format obs diag
    listall_cnv_bin="conv"
    for type in $listall_cnv_bin; do
@@ -697,20 +702,26 @@ esac
          `${CAT} pe*.${type}_${loop}* > diag_${type}_${string}.${cycle_str}`
       fi
    done
+
+#========================================================================================#
 #  netcdf format obs diag
-   if [[ "${L_NCDIAG}" == ".true." ]] || [[ "${L_NCDIAG}" == ".TRUE." ]]  ; then
-      listall_cnv_nc4="uv t q ps gust vis"
-      if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
-         listall_cnv_nc4="${listall_cnv_nc4} howv"
-      fi
-      for type in $listall_cnv_nc4; do
-        count=`ls pe*.conv_${type}_${loop}.nc4 | wc -l`
-        if [[ $count -gt 0 ]]; then
-           find ${DATA} -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
-           $nc_diag_cat -o diag_${type}_${string}.${cycle_str}.HRRR.nc4 pe*.conv_${type}_${loop}.nc4 
-        fi
-      done
-   fi
+#    the following lines to concatenate nc4 obs-diag takes too much time, 
+#    they were taken out and put into a separate step (see scripts/exrtma3d_ncdiag.ksh)
+#  if [[ "${RUN_NCDIAG}" =~ [YyTt] ]] ; then
+#     listall_cnv_nc4="uv t q ps gust vis"
+#     if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
+#        listall_cnv_nc4="${listall_cnv_nc4} howv"
+#     fi
+#     for type in $listall_cnv_nc4; do
+#        count=`ls pe*.conv_${type}_${loop}.nc4 | wc -l`
+#        if [[ $count -gt 0 ]]; then
+#           find ${DATA}/ -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
+#           $nc_diag_cat -o diag_${type}_${string}.${cycle_str}.${RUN}.nc4 pe*.conv_${type}_${loop}.nc4 
+#        fi
+#     done
+#  fi
+#========================================================================================#
+
 done
 
 ## link fort files with user-friendly file name

--- a/scripts/akrtma3d/exakrtma3d_gsianl.ksh
+++ b/scripts/akrtma3d/exakrtma3d_gsianl.ksh
@@ -279,8 +279,15 @@ fi
 #   bftab_sst= bufr table for sst ONLY needed for sst retrieval (retrieval=.true.)
 
 anavinfo=${FIXgsi}/rtma3d_anavinfo_arw_netcdf
-BERROR=${FIXgsi}/3drtma_berror_stats_hz01
-#BERROR=${FIXgsi}/rap_berror_stats_global_RAP_tune
+
+# Setting if (as default) using the berror file in which the De-correlation Length Scales (DLS) 
+#     had been tuned and hard-wired to 1/8 of original values from the original berror of HRRRDAS 
+  BERROR_DLS_TUNED_to_8th=${BERROR_DLS_TUNED_to_8th:-"Yes"}
+  BERROR=${FIXgsi}/3drtma_berror_stats_hz01                  # DLS tuned to 1/8 and hardwired inside
+  if [[ ${BERROR_DLS_TUNED_to_8th} =~ [NnFf] ]] ; then
+     BERROR=${FIXgsi}/rap_berror_stats_global_RAP_tune       # original berror of RAP/HRRR
+  fi
+
 SATANGL=${FIXgsi}/global_satangbias.txt
 SATINFO=${FIXgsi}/global_satinfo.txt
 CONVINFO=${FIXgsi}/rtma3d_convinfo_v1.0.txt
@@ -500,12 +507,12 @@ fi
 #====  set GSI namelist options for analysis of HOWV/GUST/VIS ====#
 #  setup for howv
   corp_howv0=0.42          # static BE of howv (0.42 is tuned for pure 3DVar, needs to be changed in hyrid run)
-  hwllp_howv=170000.0      # static BE de-correlation length scale of howv (if<0, using default preset value in GSI code --> hwllp of q at level 1, which is too short)
+  hwllp_howv=100000.0      # static BE de-correlation length scale of howv (if<0, using default preset value in GSI code --> hwllp of q at level 1, which is too short)
 
 #  setup for gust
   oerr_gust=1.0            # Obs Err of gust (if<0, use preset value 1.0 defined in read_prepbufr.f90)
   corp_gust0=3.0           # static BE of gust (if<0, use preset 3.0 defined in gsi code)
-  hwllp_gust=170000.0      # static BE de-correlation length scale of gust (if <0, using default preset value in GSI)
+  hwllp_gust=100000.0      # static BE de-correlation length scale of gust (if <0, using default preset value in GSI)
 
 #  setup for visibility following 2DRTMA
   pvis=0.2                 # power index used in nonlinear transform
@@ -513,7 +520,7 @@ fi
   vis_thres=16000.0        # upper-bound set for visibility (16 km, ~10 miles)
   scale_cv=1.0             # scaling factor used in nonlinear transform
   corp_vis0=3.0            # static BE of vis (in transofrmed g-space, not in physical space)
-  hwllp_vis=170000.0       # static BE de-correlation length scale of vis (if <0, using default preset value in GSI)
+  hwllp_vis=100000.0       # static BE de-correlation length scale of vis (if <0, using default preset value in GSI)
 #  changing the static BE and OE for howv and gust in 3DRTMA hybrid EnVar run
    if [[ "${ifhyb}" == ".false." ]] || [[ "${ifhyb}" == ".FALSE." ]] ; then
       export corp_howv=${corp_howv0}
@@ -541,6 +548,27 @@ fi
 # Running GSI with more print-out information for debugging
 # (for operational run, set to .false. for less print-out to reduce wall-clock time)
   export VERBOSE_GSI=${VERBOSE_GSI:-".false."}
+
+# Setting for the factors applied to horizontal and vertical de-correlation length scales (DLS) in berror
+# if using the berror file in which the De-correlation Length Scales (DLS) had been tuned
+#    to 1/8 of the values in original berror file of RAP/HRRR, then using the 
+#    same values of hzscl & vs as used in RAP/HRRR
+  vs=1.0                      # used in RAP/HRRR
+  hzscl1=0.373                # used in RAP/HRRR
+  hzscl2=0.746                # used in RAP/HRRR
+  hzscl3=1.500                # used in RAP/HRRR
+# if DLS in berror file are not reduced to 1/8, instead the orignal berror of HRRR is used, then
+#    hzscl and vs have to be reduced to 1/8 of original values of hzscl & vs used in HRRR
+  if [[ ${BERROR_DLS_TUNED_to_8th} =~ [NnFf] ]] ; then
+#    vs=$( echo "scale=6; ${vs} * 1.0 / 8.0 " | bc )
+#    hzscl1=$( echo "scale=6; ${hzscl1} * 1.0 / 8.0 " | bc )
+#    hzscl2=$( echo "scale=6; ${hzscl2} * 1.0 / 8.0 " | bc )
+#    hzscl3=$( echo "scale=6; ${hzscl3} * 1.0 / 8.0 " | bc )
+     vs=0.125                 # 1.0   * 1/8
+     hzscl1=0.046625          # 0.373 * 1/8
+     hzscl2=0.09325           # 0.746 * 1/8
+     hzscl3=0.1875            # 1.500 * 1/8
+  fi
 
 # Build the GSI namelist on-the-fly
 [[ -f ./gsiparm.anl.sh ]] && rm -f ./gsiparm.anl.sh

--- a/scripts/akrtma3d/exakrtma3d_prepfgs.ksh
+++ b/scripts/akrtma3d/exakrtma3d_prepfgs.ksh
@@ -262,9 +262,9 @@ queried in the above while-do-loop."
    fi
 
    # save the firstguess grib2 file to $COMOUT
-#  cp -p ww3.guess.grib2 $COMOUT/${NET}.t${ww3CC}z.fgs.howv.f${ww3FHH}.grib2       # forecast time saved in name of firstguess file
-   cp -p ww3.guess.grib2 $COMOUT/${NET}.t${HH}z.fgs.howv.grib2                     # analysis time saved in name of firstguess file
-#  wgrib2 ww3.guess.grib2 -append -grib $COMOUT/${NET}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
+#  cp -p ww3.guess.grib2 $COMOUT/${RUN}.t${ww3CC}z.fgs.howv.f${ww3FHH}.grib2       # forecast time saved in name of firstguess file
+   cp -p ww3.guess.grib2 $COMOUT/${RUN}.t${HH}z.fgs.howv.grib2                     # analysis time saved in name of firstguess file
+#  wgrib2 ww3.guess.grib2 -append -grib $COMOUT/${RUN}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
 
 # 3. Appending Wave height (2-D) field to 3D-RTMA firstguess file (netcdf format)
 
@@ -389,9 +389,9 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
          wgrib2 ./hrrr_guess.grib2 -match "${FHH_string}" -grib ./gust.guess.grib2
          export err=$?; err_chk
          # save the firstguess grib2 file to $COMOUT
-#        cp -p ./gust.guess.grib2 $COMOUT/${NET}.t${PRE_HH}z.fgs.gust.f0${ind}.grib2       # forecast time saved in name of firstguess file
-         cp -p ./gust.guess.grib2 $COMOUT/${NET}.t${HH}z.fgs.gust.grib2                   # analysis time saved in name of firstguess file
-#        wgrib2 gust.guess.grib2 -append -grib $COMOUT/${NET}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
+#        cp -p ./gust.guess.grib2 $COMOUT/${RUN}.t${PRE_HH}z.fgs.gust.f0${ind}.grib2       # forecast time saved in name of firstguess file
+         cp -p ./gust.guess.grib2 $COMOUT/${RUN}.t${HH}z.fgs.gust.grib2                   # analysis time saved in name of firstguess file
+#        wgrib2 gust.guess.grib2 -append -grib $COMOUT/${RUN}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
 
          found_gustges=yes
 
@@ -529,9 +529,9 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
          wgrib2 ./hrrr_guess.grib2 -match "${FHH_string}" -rpn "16000:min" -grib_out ./vis.guess.grib2
          export err=$?; err_chk
          # save the firstguess grib2 file to $COMOUT
-#        cp -p ./vis.guess.grib2 $COMOUT/${NET}.t${PRE_HH}z.fgs.vis.f0${ind}.grib2       # forecast time saved in name of firstguess file
-         cp -p ./vis.guess.grib2 $COMOUT/${NET}.t${HH}z.fgs.vis.grib2                   # analysis time saved in name of firstguess file
-#        wgrib2  vis.guess.grib2 -append -grib $COMOUT/${NET}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
+#        cp -p ./vis.guess.grib2 $COMOUT/${RUN}.t${PRE_HH}z.fgs.vis.f0${ind}.grib2       # forecast time saved in name of firstguess file
+         cp -p ./vis.guess.grib2 $COMOUT/${RUN}.t${HH}z.fgs.vis.grib2                   # analysis time saved in name of firstguess file
+#        wgrib2  vis.guess.grib2 -append -grib $COMOUT/${RUN}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
 
          found_visges=yes
 

--- a/scripts/exrtma3d_autoqc.ksh
+++ b/scripts/exrtma3d_autoqc.ksh
@@ -71,9 +71,19 @@ for ftype in ges anl; do
   fi
   gunzip ${diagfile}.gz
   ln -sf ${diagfile} diag_conv.dat
+
+  # namelist file for running READDIAG (=> rtma3d_read_diag.exe)
+  [[ -f ./namelist.conv ]] && rm -f ./namelist.conv
+cat << EOF > ./namelist.conv
+&iosetup
+    dump_pseudo_obs_too=.true.,
+/
+EOF
+
   ${READDIAG} diag_conv.dat
   mv diag_results ${diagfile}
   rm diag_conv.dat
+  [[ -f ./namelist.conv ]] && mv ./namelist.conv ./namelist.conv.readdiag.${ftype}  # saving namelist for check
 
 done
 

--- a/scripts/exrtma3d_ncdiag.ksh
+++ b/scripts/exrtma3d_ncdiag.ksh
@@ -1,0 +1,175 @@
+#!/bin/ksh 
+set -x
+check_if_defined() { #usage: check_if_defined "var1_name" "var2_name" ...
+  for str in "$@"; do
+    eval "path=\${$str}"
+    if [ -z "${path}" ]; then
+      ${ECHO} "ERROR: \$${str} is not defined"; exit 1
+    fi
+  done
+}
+check_dirs_exist() { #usage: check_dirs_exist "var1_name" "var2_name" ...
+  for str in "$@"; do
+    eval "path=\${$str}"
+    if [ ! -d ${path} ]; then
+      ${ECHO} "ERROR: ${path}/ does not exist"; exit 1
+    fi
+  done
+}
+
+# Set the name to the executable of ncdiag (default: using serial code)
+  export exefile_name_ncdiag=${exefile_name_ncdiag:-"ncdiag_cat_serial.x"}
+
+if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then
+
+# make sure executable exists
+  if [ -n ${ncdiag_VERSION} ] && [ -d ${ncdiag_ROOT} ] ; then  # module ncdiag was loaded successfully on wcoss2
+    PATH_to_NCDIAG="{ncdiag_ROOT}/bin"                         # path to ncdiag exe already added into $PATH
+    nc_diag_cat=${PATH_to_NCDIAG}/${exefile_name_ncdiag}
+    echo "using ${nc_diag_cat} to concatenate nc4 obs-diag files ..."
+  elif [ -f ${EXECrtma3d}/ncdiag_cat_serial.x ] ; then
+    nc_diag_cat=${EXECrtma3d}/ncdiag_cat_serial.x
+    echo "using ${nc_diag_cat} to concatenate nc4 obs-diag files ..."
+  else
+    ${ECHO} "ERROR: executable to concatenate netcdf obs-diag file '${exefile_name_gsi}' could not be found! ncdiag job abort ..."
+    err_exit
+  fi
+
+fi
+
+# Directory where the original not-comnbined nc4 obs-diag files are saved
+#           (default ==> GSI RUNING/WORKING directory)
+  DATAGSI=${DATAGSIHOME:-"../gsiprd"}
+
+# Compute date & time components for the analysis time
+  subcyc=${subcyc:-"00"}
+  START_TIME=`${DATE} -d "${PDY} ${cyc} ${subcyc} minutes"`
+  YYYYMMDDHH=`${DATE} +"%Y%m%d%H" -d "${START_TIME}"`
+  YYYYMMDDHHMM=`${DATE} +"%Y%m%d%H%M" -d "${START_TIME}"`
+  cycle_str=${PDY}${cyc}
+
+#----- enter working directory -------
+  cd ${DATA}
+  ${ECHO} "enter working directory:${DATA}"
+
+# option for netcdf-format obs diag file
+  RUN_NCDIAG=${RUN_NCDIAG:-"Yes"} # netcdf format obs-diag file (default: Yes)
+  if [[ "${RUN_NCDIAG}" =~ [YfTt] ]]  ; then
+
+#========================================================================================#
+#    searching for the max outer-loop
+     maxlimit=51
+     imax=1
+     found_loopend=no
+     loopend="01"
+     loops=""
+     while [[ $imax -ge 1 ]] && [[ $found_loopend =~ [NnFf] ]] && [[ $imax -le $maxlimit ]]
+     do
+        ima2=`printf %02d $imax`
+        n_found=0
+#       n_found=`find ${DATAGSI} -type f -name "pe*.conv_t_${ima2}.nc4" | wc -l`
+        n_found=`ls ${DATAGSI}/pe*.conv_t_${ima2}.nc4 | wc -l`
+        if [[ "${n_found}" -gt 0 ]] ; then
+           loops="$loops $ima2"
+           found_loopend="no"      # keep searching
+           let "imax=imax+1"
+        else
+           if [[ $imax -eq 1 ]] ; then
+              echo "WARNING:==> Even no diag file was found for outer-loop ${imax}. Abort this ncdiag job ..."
+              found_loopend="no"
+              err_exit
+           else
+              found_loopend="yes"
+              break                # jump out the search.
+           fi
+        fi
+     done
+     if [[ ${found_loopend} =~ [NnFf] ]] ; then
+        echo "WARNING:==> There is diag file for outer-loop larger than $maxlimit. This is ABNORMAL. Please double check your GSI running configuration."
+        err_exit
+     else
+        let "imax=imax-1"
+        loopend=`printf %02d $imax`
+        echo "Max outer-loop index = ${loopend}"
+     fi
+  
+#========================================================================================#
+#    searching for avaialble obs variables
+     listall_conv="uv t q ps gust vis howv"
+     listall_conv_nc4=""
+     nvar=0
+     for ivar in ${listall_conv}
+     do
+#       n_ivar=`find ${DATAGSI} -type f -name "pe*.conv_${ivar}_01.nc4" | wc -l`
+        n_ivar=`ls ${DATAGSI}/pe*.conv_${ivar}_01.nc4 | wc -l`
+        if [[ ${n_ivar} -gt 0 ]] ; then
+           listall_conv_nc4="${listall_conv_nc4} ${ivar}"
+           nvar=$nvar+1
+        fi
+     done
+     echo "nc4 obs-diag files are avaible for $nvar obs ==> ${listall_conv_nc4}"
+
+#========================================================================================#
+#  creating command file for CFP on wcoss2
+
+     rm -f ${DATA}/ncdiag_cmdfile
+     icount=0
+
+# The following lines are copied from original gsianl.ksh
+#
+# Loop over first and last outer loops to generate innovation
+# diagnostic files for indicated observation types (groups)
+#
+# NOTE:  Since we set miter=2 in GSI namelist SETUP, outer
+#        loop 03 will contain innovations with respect to 
+#        the analysis.  Creation of o-a innovation files
+#        is triggered by write_diag(3)=.true.  The setting
+#        write_diag(1)=.true. turns on creation of o-g
+#        innovation files.
+#
+#    loops="01 02 03"    # loops and loopend are found in the do-while block above.
+     echo "outer-loops is $loops"
+     for loop in $loops; do
+
+        case $loop in
+           01) string=ges;;
+           $loopend) string=anl;;
+           *) string=$loop;;
+        esac
+
+#  Collect diagnostic files for obs types (groups) below
+#       listall="hirs2_n14 msu_n14 sndr_g08 sndr_g11 sndr_g11 sndr_g12 sndr_g13 sndr_g08_prep sndr_g11_prep sndr_g12_prep sndr_g13_prep sndrd1_g11 sndrd2_g11 sndrd3_g11 sndrd4_g11 sndrd1_g12 sndrd2_g12 sndrd3_g12 sndrd4_g12 sndrd1_g13 sndrd2_g13 sndrd3_g13 sndrd4_g13 hirs3_n15 hirs3_n16 hirs3_n17 amsua_n15 amsua_n16 amsua_n17 amsub_n15 amsub_n16 amsub_n17 hsb_aqua airs_aqua amsua_aqua imgr_g08 imgr_g11 imgr_g12 pcp_ssmi_dmsp pcp_tmi_trmm conv sbuv2_n16 sbuv2_n17 sbuv2_n18 omi_aura ssmi_f13 ssmi_f14 ssmi_f15 hirs4_n18 hirs4_metop-a amsua_n18 amsua_metop-a mhs_n18 mhs_metop-a amsre_low_aqua amsre_mid_aqua amsre_hig_aqua ssmis_las_f16 ssmis_uas_f16 ssmis_img_f16 ssmis_env_f16 iasi_metop-a"
+
+
+#  binary format obs diag
+#  netcdf format obs diag
+        for type in $listall_conv_nc4; do
+           count=`ls ${DATAGSI}/pe*.conv_${type}_${loop}.nc4 | wc -l`
+           if [[ $count -gt 0 ]]; then
+              find ${DATAGSI} -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
+              echo "$nc_diag_cat -o ${DATA}/diag_${type}_${string}.${cycle_str}.${RUN}.nc4 ${DATAGSI}/pe*.conv_${type}_${loop}.nc4" >> ${DATA}/ncdiag_cmdfile
+              icount=$icount+1
+           fi
+        done
+     done
+
+#    Execute the command file with CFP
+     export exeName=cfp
+     export CMDFILE=${DATA}/ncdiag_cmdfile
+     command="mpiexec -np 6 --cpu-bind verbose,core ${exeName} $CMDFILE >>$pgmout 2>errfile"
+     echo $command
+     $command
+     export err=$?; err_chk
+     echo "using $exeName to run ncdiag COMPLETED"
+  
+#    Saving combined nc4 obs-daig files to COM2
+     ${CP} -p ${DATA}/diag_*.${RUN}.nc4 ${COMOUTgsi_rtma3d}  
+     gzip ${COMOUTgsi_rtma3d}/diag_*.${RUN}.nc4
+
+  else
+
+     echo "RUN_NCDIAG is set to be $RUN_NCDIAG, so no running of concatenation of nc4 obs-diag files for this cycle ${cycle_str}"
+
+  fi
+
+  exit

--- a/scripts/exrtma3d_ncdiag.ksh
+++ b/scripts/exrtma3d_ncdiag.ksh
@@ -24,7 +24,7 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then
 
 # make sure executable exists
   if [ -n ${ncdiag_VERSION} ] && [ -d ${ncdiag_ROOT} ] ; then  # module ncdiag was loaded successfully on wcoss2
-    PATH_to_NCDIAG="{ncdiag_ROOT}/bin"                         # path to ncdiag exe already added into $PATH
+    PATH_to_NCDIAG="${ncdiag_ROOT}/bin"                        # path to ncdiag exe already added into $PATH
     nc_diag_cat=${PATH_to_NCDIAG}/${exefile_name_ncdiag}
     echo "using ${nc_diag_cat} to concatenate nc4 obs-diag files ..."
   elif [ -f ${EXECrtma3d}/ncdiag_cat_serial.x ] ; then
@@ -51,6 +51,7 @@ fi
 #----- enter working directory -------
   cd ${DATA}
   ${ECHO} "enter working directory:${DATA}"
+  rm -rf ${DATA}/*
 
 # option for netcdf-format obs diag file
   RUN_NCDIAG=${RUN_NCDIAG:-"Yes"} # netcdf format obs-diag file (default: Yes)
@@ -67,7 +68,7 @@ fi
      do
         ima2=`printf %02d $imax`
         n_found=0
-#       n_found=`find ${DATAGSI} -type f -name "pe*.conv_t_${ima2}.nc4" | wc -l`
+#       n_found=`find ${DATAGSI}/ -type f -name "pe*.conv_t_${ima2}.nc4" | wc -l`
         n_found=`ls ${DATAGSI}/pe*.conv_t_${ima2}.nc4 | wc -l`
         if [[ "${n_found}" -gt 0 ]] ; then
            loops="$loops $ima2"
@@ -100,11 +101,12 @@ fi
      nvar=0
      for ivar in ${listall_conv}
      do
-#       n_ivar=`find ${DATAGSI} -type f -name "pe*.conv_${ivar}_01.nc4" | wc -l`
+#       n_ivar=`find ${DATAGSI}/ -type f -name "pe*.conv_${ivar}_01.nc4" | wc -l`
         n_ivar=`ls ${DATAGSI}/pe*.conv_${ivar}_01.nc4 | wc -l`
         if [[ ${n_ivar} -gt 0 ]] ; then
            listall_conv_nc4="${listall_conv_nc4} ${ivar}"
-           nvar=$nvar+1
+#          let "nvar=nvar+1"
+           nvar=$((nvar + 1 ))
         fi
      done
      echo "nc4 obs-diag files are avaible for $nvar obs ==> ${listall_conv_nc4}"
@@ -146,9 +148,13 @@ fi
         for type in $listall_conv_nc4; do
            count=`ls ${DATAGSI}/pe*.conv_${type}_${loop}.nc4 | wc -l`
            if [[ $count -gt 0 ]]; then
-              find ${DATAGSI} -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
+#              take out the small size files (<1k, no data inside) and remove them
+#               Then no warning message when running ncdiag_cat. 
+#               But even running with the small files, the results are same.
+              find ${DATAGSI}/ -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
               echo "$nc_diag_cat -o ${DATA}/diag_${type}_${string}.${cycle_str}.${RUN}.nc4 ${DATAGSI}/pe*.conv_${type}_${loop}.nc4" >> ${DATA}/ncdiag_cmdfile
-              icount=$icount+1
+#             let "icount=icount+1"
+              icount=$((icount + 1))
            fi
         done
      done
@@ -156,15 +162,19 @@ fi
 #    Execute the command file with CFP
      export exeName=cfp
      export CMDFILE=${DATA}/ncdiag_cmdfile
-     command="mpiexec -np 6 --cpu-bind verbose,core ${exeName} $CMDFILE >>$pgmout 2>errfile"
+#    command="mpiexec -np 6 --cpu-bind verbose,core ${exeName} $CMDFILE >>$pgmout 2>errfile"
+     command="mpiexec -np ${nvar} --cpu-bind verbose,core ${exeName} $CMDFILE >>$pgmout 2>errfile"
      echo $command
      $command
      export err=$?; err_chk
      echo "using $exeName to run ncdiag COMPLETED"
   
-#    Saving combined nc4 obs-daig files to COM2
-     ${CP} -p ${DATA}/diag_*.${RUN}.nc4 ${COMOUTgsi_rtma3d}  
-     gzip ${COMOUTgsi_rtma3d}/diag_*.${RUN}.nc4
+#    Saving combined nc4 obs-daig files to COM2 and compressing thme with gzip to save space
+     for type in $listall_conv_nc4; do
+        ${CP} -p ${DATA}/diag_${type}_*.${cycle_str}.${RUN}.nc4      ${COMOUTgsi_rtma3d}
+        rm -f ${COMOUTgsi_rtma3d}/diag_${type}_*.${cycle_str}.${RUN}.nc4.gz
+        gzip  ${COMOUTgsi_rtma3d}/diag_${type}_*.${cycle_str}.${RUN}.nc4
+     done
 
   else
 

--- a/scripts/rtma3d/exrtma3d_anldump.ksh
+++ b/scripts/rtma3d/exrtma3d_anldump.ksh
@@ -243,11 +243,11 @@ postmsg "$jlogfile" "$msg"
         if [ $err -eq 0 ] ; then
            echo "           Successfully convert netcdf file to grib2 file for ${varname}."
            # save the analysis file (grib2) to $COMOUT
-#          cp -p ./${grib2_fname}     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2     
-           cp -p tmpout.grib2tmp     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2
+#          cp -p ./${grib2_fname}     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2     
+           cp -p tmpout.grib2tmp     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2
            # appending to a single grib2 file
-#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
-#          wgrib2 tmpout.grib2tmp      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 tmpout.grib2tmp      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
         else
            echo "conversion of ${varname} in analysis from netcdf to grib2 failed."
         fi
@@ -299,9 +299,9 @@ postmsg "$jlogfile" "$msg"
         if [ $err -eq 0 ] ; then
            echo "           Successfully convert netcdf file to grib2 file for ${varname}."
            # save the analysis file (grib2) to $COMOUT
-           cp -p ./${grib2_fname}     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2     
+           cp -p ./${grib2_fname}     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2     
            # appending to a single grib2 file
-#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
         else
            echo "conversion of ${varname} in analysis from netcdf to grib2 failed."
         fi
@@ -353,9 +353,9 @@ postmsg "$jlogfile" "$msg"
         if [ $err -eq 0 ] ; then
            echo "           Successfully convert netcdf file to grib2 file for ${varname}."
            # save the analysis file (grib2) to $COMOUT
-           cp -p ./${grib2_fname}     ${COMOUT}/${NET}.t${HH}z.anl.${varname}.grib2     
+           cp -p ./${grib2_fname}     ${COMOUT}/${RUN}.t${HH}z.anl.${varname}.grib2     
            # appending to a single grib2 file
-#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${NET}.t${HH}z.anl.DirectAnl2Ds.grib2
+#          wgrib2 ${grib2_fname}      -append -grib ${COMOUT}/${RUN}.t${HH}z.anl.DirectAnl2Ds.grib2
         else
            echo "conversion of ${varname} in analysis from netcdf to grib2 failed."
         fi

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -292,8 +292,15 @@ fi
 #   bftab_sst= bufr table for sst ONLY needed for sst retrieval (retrieval=.true.)
 
 anavinfo=${FIXgsi}/rtma3d_anavinfo_arw_netcdf
-BERROR=${FIXgsi}/3drtma_berror_stats_hz01
-#BERROR=${FIXgsi}/rap_berror_stats_global_RAP_tune
+
+# Setting if (as default) using the berror file in which the De-correlation Length Scales (DLS) 
+#     had been tuned and hard-wired to 1/8 of original values from the original berror of HRRRDAS 
+  BERROR_DLS_TUNED_to_8th=${BERROR_DLS_TUNED_to_8th:-"Yes"}
+  BERROR=${FIXgsi}/3drtma_berror_stats_hz01                  # DLS tuned to 1/8 and hardwired inside
+  if [[ ${BERROR_DLS_TUNED_to_8th} =~ [NnFf] ]] ; then
+     BERROR=${FIXgsi}/rap_berror_stats_global_RAP_tune       # original berror of RAP/HRRR
+  fi
+
 SATANGL=${FIXgsi}/global_satangbias.txt
 SATINFO=${FIXgsi}/global_satinfo.txt
 CONVINFO=${FIXgsi}/rtma3d_convinfo_v1.0.txt
@@ -513,12 +520,12 @@ fi
 #====  set GSI namelist options for analysis of HOWV/GUST/VIS ====#
 #  setup for howv
   corp_howv0=0.42          # static BE of howv (0.42 is tuned for pure 3DVar, needs to be changed in hyrid run)
-  hwllp_howv=170000.0      # static BE de-correlation length scale of howv (if<0, using default preset value in GSI code --> hwllp of q at level 1, which is too short)
+  hwllp_howv=100000.0      # static BE de-correlation length scale of howv (if<0, using default preset value in GSI code --> hwllp of q at level 1, which is too short)
 
 #  setup for gust
   oerr_gust=1.0            # Obs Err of gust (if<0, use preset value 1.0 defined in read_prepbufr.f90)
   corp_gust0=3.0           # static BE of gust (if<0, use preset 3.0 defined in gsi code)
-  hwllp_gust=170000.0      # static BE de-correlation length scale of gust (if <0, using default preset value in GSI)
+  hwllp_gust=100000.0      # static BE de-correlation length scale of gust (if <0, using default preset value in GSI)
 
 #  setup for visibility following 2DRTMA
   pvis=0.2                 # power index used in nonlinear transform
@@ -526,7 +533,7 @@ fi
   vis_thres=16000.0        # upper-bound set for visibility (16 km, ~10 miles)
   scale_cv=1.0             # scaling factor used in nonlinear transform
   corp_vis0=3.0            # static BE of vis (in transofrmed g-space, not in physical space)
-  hwllp_vis=170000.0       # static BE de-correlation length scale of vis (if <0, using default preset value in GSI)
+  hwllp_vis=100000.0       # static BE de-correlation length scale of vis (if <0, using default preset value in GSI)
 #  changing the static BE and OE for howv and gust in 3DRTMA hybrid EnVar run
    if [[ "${ifhyb}" == ".false." ]] || [[ "${ifhyb}" == ".FALSE." ]] ; then
       export corp_howv=${corp_howv0}
@@ -554,6 +561,27 @@ fi
 # Running GSI with more print-out information for debugging
 # (for operational run, set to .false. for less print-out to reduce wall-clock time)
   export VERBOSE_GSI=${VERBOSE_GSI:-".false."}
+
+# Setting for the factors applied to horizontal and vertical de-correlation length scales (DLS) in berror
+# if using the berror file in which the De-correlation Length Scales (DLS) had been tuned
+#    to 1/8 of the values in original berror file of RAP/HRRR, then using the 
+#    same values of hzscl & vs as used in RAP/HRRR
+  vs=1.0                      # used in RAP/HRRR
+  hzscl1=0.373                # used in RAP/HRRR
+  hzscl2=0.746                # used in RAP/HRRR
+  hzscl3=1.500                # used in RAP/HRRR
+# if DLS in berror file are not reduced to 1/8, instead the orignal berror of HRRR is used, then
+#    hzscl and vs have to be reduced to 1/8 of original values of hzscl & vs used in HRRR
+  if [[ ${BERROR_DLS_TUNED_to_8th} =~ [NnFf] ]] ; then
+#    vs=$( echo "scale=6; ${vs} * 1.0 / 8.0 " | bc )
+#    hzscl1=$( echo "scale=6; ${hzscl1} * 1.0 / 8.0 " | bc )
+#    hzscl2=$( echo "scale=6; ${hzscl2} * 1.0 / 8.0 " | bc )
+#    hzscl3=$( echo "scale=6; ${hzscl3} * 1.0 / 8.0 " | bc )
+     vs=0.125                 # 1.0   * 1/8
+     hzscl1=0.046625          # 0.373 * 1/8
+     hzscl2=0.09325           # 0.746 * 1/8
+     hzscl3=0.1875            # 1.500 * 1/8
+  fi
 
 # Build the GSI namelist on-the-fly
 [[ -f ./gsiparm.anl.sh ]] && rm -f ./gsiparm.anl.sh

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -215,7 +215,7 @@ if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC 
   EnsWgt=0.9
   nummem=${hrrrmem}
   cpreq filelist.hrrrdas filelist03
-  ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
+  rm -f ./hybens_info
   beta1_inv=$(( 1 - $EnsWgt  ))
   ifhyb=.true.
   regional_ensemble_option=3
@@ -224,12 +224,14 @@ if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC 
   ens_fast_read=.true. 
   if [[ "${READIN_LOCALIZATION}" == "TRUE" ]] || [[ "${READIN_LOCALIZATION}" == "true" ]] ; then
      readin_localization=.true.
+     HYBENS_INFO=${PARMgsi}/hybens_info_hrrrdas
+     ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
   fi
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses HRRRDAS BEC with n_ens=${nummem}" >> ${pgmout}
 elif [[ ${nummem} -eq 80 ]]; then
   echo "Do hybrid with GDAS directly"
+  rm -f ./hybens_info
   EnsWgt=0.5
-  ${CP} ${PARMgsi}/hybens_info_hrrrdas hybens_info
   beta1_inv=$(( 1 - $EnsWgt  ))
   ifhyb=.true.
   regional_ensemble_option=1
@@ -238,6 +240,8 @@ elif [[ ${nummem} -eq 80 ]]; then
   ens_fast_read=.false. 
   if [[ "${READIN_LOCALIZATION}" == "TRUE" ]] || [[ "${READIN_LOCALIZATION}" == "true" ]] ; then
      readin_localization=.true.
+     HYBENS_INFO=${PARMgsi}/hybens_info
+     ${CP} ${PARMgsi}/hybens_info hybens_info
   fi
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses GDAS directly with n_ens=${nummem}" >> ${pgmout}
 else
@@ -252,13 +256,10 @@ else
 fi
 
 # copy the read-in localization file for hybrid envar analysis
-  HYBENS_INFO="hybens_info"
   if [[ "${readin_localization}" == ".true." ]] ; then
-     cp -p ${PARMgsi}/${HYBENS_INFO}  hybens_info
      
      # read in the weight for static background error at the surface level in hybrid envar run
      # the weight would be used to adjust the background error for howv/gust/vis
-     hybens_info_file="hybens_info"
      n=0
      set +x
      while read line_str
@@ -269,7 +270,7 @@ fi
            echo "Weight of static background error at level $n  --> $StaticWgt"
         fi
         let "n=n+1"
-     done < "$hybens_info_file"
+     done < ./hybens_info
      set -x
   else
      StaticWgt=${beta1_inv}

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -515,7 +515,12 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #WCOSS
 fi
 
 # option for netcdf-format obs diag file
-  L_NCDIAG=${L_NCDIAG:-".false."}     # false: no output of netcdf obsdiag, and do not combine them
+  RUN_NCDIAG=${RUN_NCDIAG:-"Yes"} # netcdf format obs-diag file (default: Yes)
+  if [[ ${RUN_NCDIAG} =~ [TtYy] ]] ; then
+     L_NCDIAG=".true."            # gsi dumps out netcdf obsdiag, run ncdiag to combine them
+  else
+     L_NCDIAG=".false."
+  fi
 
 #====  set GSI namelist options for analysis of HOWV/GUST/VIS ====#
 #  setup for howv
@@ -701,7 +706,6 @@ esac
 #  Collect diagnostic files for obs types (groups) below
 #  listall="hirs2_n14 msu_n14 sndr_g08 sndr_g11 sndr_g11 sndr_g12 sndr_g13 sndr_g08_prep sndr_g11_prep sndr_g12_prep sndr_g13_prep sndrd1_g11 sndrd2_g11 sndrd3_g11 sndrd4_g11 sndrd1_g12 sndrd2_g12 sndrd3_g12 sndrd4_g12 sndrd1_g13 sndrd2_g13 sndrd3_g13 sndrd4_g13 hirs3_n15 hirs3_n16 hirs3_n17 amsua_n15 amsua_n16 amsua_n17 amsub_n15 amsub_n16 amsub_n17 hsb_aqua airs_aqua amsua_aqua imgr_g08 imgr_g11 imgr_g12 pcp_ssmi_dmsp pcp_tmi_trmm conv sbuv2_n16 sbuv2_n17 sbuv2_n18 omi_aura ssmi_f13 ssmi_f14 ssmi_f15 hirs4_n18 hirs4_metop-a amsua_n18 amsua_metop-a mhs_n18 mhs_metop-a amsre_low_aqua amsre_mid_aqua amsre_hig_aqua ssmis_las_f16 ssmis_uas_f16 ssmis_img_f16 ssmis_env_f16 iasi_metop-a"
 
-
 #  binary format obs diag
    listall_cnv_bin="conv"
    for type in $listall_cnv_bin; do
@@ -710,20 +714,26 @@ esac
          `${CAT} pe*.${type}_${loop}* > diag_${type}_${string}.${cycle_str}`
       fi
    done
+
+#========================================================================================#
 #  netcdf format obs diag
-   if [[ "${L_NCDIAG}" == ".true." ]] || [[ "${L_NCDIAG}" == ".TRUE." ]]  ; then
-      listall_cnv_nc4="uv t q ps gust vis"
-      if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
-         listall_cnv_nc4="${listall_cnv_nc4} howv"
-      fi
-      for type in $listall_cnv_nc4; do
-        count=`ls pe*.conv_${type}_${loop}.nc4 | wc -l`
-        if [[ $count -gt 0 ]]; then
-           find ${DATA} -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
-           $nc_diag_cat -o diag_${type}_${string}.${cycle_str}.HRRR.nc4 pe*.conv_${type}_${loop}.nc4 
-        fi
-      done
-   fi
+#    the following lines to concatenate nc4 obs-diag takes too much time, 
+#    they were taken out and put into a separate step (see scripts/exrtma3d_ncdiag.ksh)
+#  if [[ "${RUN_NCDIAG}" =~ [YyTt] ]] ; then
+#     listall_cnv_nc4="uv t q ps gust vis"
+#     if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
+#        listall_cnv_nc4="${listall_cnv_nc4} howv"
+#     fi
+#     for type in $listall_cnv_nc4; do
+#       count=`ls pe*.conv_${type}_${loop}.nc4 | wc -l`
+#       if [[ $count -gt 0 ]]; then
+#          find ${DATA} -type f -name "pe*.conv_${type}_${loop}.nc4" -size 1k -delete
+#          $nc_diag_cat -o diag_${type}_${string}.${cycle_str}.HRRR.nc4 pe*.conv_${type}_${loop}.nc4 
+#       fi
+#     done
+#  fi
+#========================================================================================#
+
 done
 
 ## link fort files with user-friendly file name

--- a/scripts/rtma3d/exrtma3d_prepfgs.ksh
+++ b/scripts/rtma3d/exrtma3d_prepfgs.ksh
@@ -261,9 +261,9 @@ queried in the above while-do-loop."
    fi
 
    # save the firstguess grib2 file to $COMOUT
-#  cp -p ww3.guess.grib2 $COMOUT/${NET}.t${ww3CC}z.fgs.howv.f${ww3FHH}.grib2       # forecast time saved in name of firstguess file
-   cp -p ww3.guess.grib2 $COMOUT/${NET}.t${HH}z.fgs.howv.grib2                     # analysis time saved in name of firstguess file
-#  wgrib2 ww3.guess.grib2 -append -grib $COMOUT/${NET}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
+#  cp -p ww3.guess.grib2 $COMOUT/${RUN}.t${ww3CC}z.fgs.howv.f${ww3FHH}.grib2       # forecast time saved in name of firstguess file
+   cp -p ww3.guess.grib2 $COMOUT/${RUN}.t${HH}z.fgs.howv.grib2                     # analysis time saved in name of firstguess file
+#  wgrib2 ww3.guess.grib2 -append -grib $COMOUT/${RUN}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
 
 # 3. Appending Wave height (2-D) field to 3D-RTMA firstguess file (netcdf format)
 
@@ -387,9 +387,9 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
          wgrib2 ./hrrr_guess.grib2 -match "${FHH_string}" -grib ./gust.guess.grib2
          export err=$?; err_chk
          # save the firstguess grib2 file to $COMOUT
-#        cp -p ./gust.guess.grib2 $COMOUT/${NET}.t${PRE_HH}z.fgs.gust.f${ic2}.grib2       # forecast time saved in name of firstguess file
-         cp -p ./gust.guess.grib2 $COMOUT/${NET}.t${HH}z.fgs.gust.grib2                   # analysis time saved in name of firstguess file
-#        wgrib2 gust.guess.grib2 -append -grib $COMOUT/${NET}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
+#        cp -p ./gust.guess.grib2 $COMOUT/${RUN}.t${PRE_HH}z.fgs.gust.f${ic2}.grib2       # forecast time saved in name of firstguess file
+         cp -p ./gust.guess.grib2 $COMOUT/${RUN}.t${HH}z.fgs.gust.grib2                   # analysis time saved in name of firstguess file
+#        wgrib2 gust.guess.grib2 -append -grib $COMOUT/${RUN}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
 
          found_gustges=yes
 
@@ -525,9 +525,9 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
          wgrib2 ./hrrr_guess.grib2 -match "${FHH_string}" -rpn "16000:min" -grib_out ./vis.guess.grib2
          export err=$?; err_chk
          # save the firstguess grib2 file to $COMOUT
-#        cp -p ./vis.guess.grib2 $COMOUT/${NET}.t${PRE_HH}z.fgs.vis.f${ic2}.grib2       # forecast time saved in name of firstguess file
-         cp -p ./vis.guess.grib2 $COMOUT/${NET}.t${HH}z.fgs.vis.grib2                   # analysis time saved in name of firstguess file
-#        wgrib2  vis.guess.grib2 -append -grib $COMOUT/${NET}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
+#        cp -p ./vis.guess.grib2 $COMOUT/${RUN}.t${PRE_HH}z.fgs.vis.f${ic2}.grib2       # forecast time saved in name of firstguess file
+         cp -p ./vis.guess.grib2 $COMOUT/${RUN}.t${HH}z.fgs.vis.grib2                   # analysis time saved in name of firstguess file
+#        wgrib2  vis.guess.grib2 -append -grib $COMOUT/${RUN}.t${HH}z.fgs.DirectAnl2Ds.grib2  # single grib2 file
 
          found_visges=yes
 

--- a/sorc/rtma3d_read_diag.fd/rtma3d_read_diag.f90
+++ b/sorc/rtma3d_read_diag.fd/rtma3d_read_diag.f90
@@ -91,6 +91,8 @@ PROGRAM read_diag_conv
       read(11,iosetup)
      close(11)
   endif
+  write(6,*) ' *** writing out the namelist options for check-up *** '
+  write(6,iosetup)
 !
   open(42, file=trim(outfilename),IOSTAT=ios)
   if(ios > 0 ) then
@@ -126,6 +128,8 @@ PROGRAM read_diag_conv
               var(1:3)=='hwv' .or. var(1:3)=='vis')                          &
               read(17, ERR=999, end=110) cprvstg, csprvstg
           do i=1,ii
+             isubtype = -999        ! initialising isubtype & isubtype0 before processing every obs
+             isubtype0= -999
              cprovider=cprvstg(i)
              csubprovider=csprvstg(i)
              itype=rdiagbuf(1,i)    ! observation type
@@ -266,7 +270,7 @@ PROGRAM read_diag_conv
                    var,stationID,cprovider,csubprovider,itype,rdhr,rlat,rlon,rprs,rhgt,iuse,robs1,ddiff,robs2,rdpt2,rerr,iusev
              endif
 
-          enddo   ! i  end for one station
+          enddo   ! i loop end for one station (do i=1,ii)
 
           deallocate(cdiagbuf,rdiagbuf)
           deallocate(cprvstg,csprvstg)

--- a/util_dev/build_gsi4rtma3d.sh
+++ b/util_dev/build_gsi4rtma3d.sh
@@ -35,6 +35,11 @@ CONTROLPATH="$DIR_ROOT/../develop/install/bin"
 # Collect BUILD Options
 CMAKE_OPTS+=" -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
 
+# Set bufr flag based on machine
+if [[ $MACHINE_ID == 'ursa' || $MACHINE_ID == 'acorn' || $MACHINE_ID == 'wcoss2' ]]; then
+    CMAKE_OPTS+=" -DUSE_BUFR12=ON"
+fi
+
 # Install destination for built executables, libraries, CMake Package config
 CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX"
 

--- a/workflow/rtma3d_pbspro_alaska.xml
+++ b/workflow/rtma3d_pbspro_alaska.xml
@@ -133,7 +133,7 @@
 <!ENTITY maxtries	"3">
 <!ENTITY KEEPDATA	"YES">
 <!ENTITY SENDCOM	"YES">
-<!ENTITY RUN_RHIST	"YES">
+<!ENTITY RUN_RHIST	"No">
 <!ENTITY RUN_HOWV	"No">
 
 <!-- for various observations used in RTMA3D -->

--- a/workflow/rtma3d_pbspro_alaska.xml
+++ b/workflow/rtma3d_pbspro_alaska.xml
@@ -19,7 +19,6 @@
 <!--<!ENTITY CAP_RUN_ENVIR	""> -->
 <!ENTITY model		"&RUN;">
 <!ENTITY HRRRDAS_BEC     "0">
-<!ENTITY READIN_LOCALIZATION     "TRUE">
 
 <!ENTITY MACHINE	"cray">
 <!ENTITY machine	"&MACHINE;">
@@ -108,6 +107,8 @@
 <!ENTITY DATA_WRFBUFR   "&DATA_RUNDIR;/wrfbufr">
 <!ENTITY DATA_POSTSND   "&DATA_RUNDIR;/wrfbufr">
 <!ENTITY DATA_RHIST     "&DATA_RUNDIR;/rhist">
+<!ENTITY DATA_NCDIAG    "&DATA_RUNDIR;/ncdiagprd">
+
 <!ENTITY hpsspath0      "/NCEPDEV/emc-meso/5year/&USER;/pbspro_rtma3d">
 <!ENTITY hpsspath1      "/NCEPPROD/hpssprod/runhistory">
 <!ENTITY hpsspath1_1yr  "/NCEPPROD/1year/hpssprod/runhistory">
@@ -135,6 +136,7 @@
 <!ENTITY SENDCOM	"YES">
 <!ENTITY RUN_RHIST	"No">
 <!ENTITY RUN_HOWV	"No">
+<!ENTITY RUN_NCDIAG	"Yes">
 
 <!-- for various observations used in RTMA3D -->
 
@@ -190,8 +192,10 @@
 <!ENTITY JJOB_POST4FGS   "&JJOB_DIR;/J&CAP_RUN;_POST4FGS">
 <!ENTITY exSCR_POST4FGS  "&SCRIPT_DIR;/ex&NET;_post4fgs.ksh">
 <!ENTITY JJOB_PRDGEN     "&JJOB_DIR;/J&CAP_RUN;_PRDGEN">
-<!ENTITY JJOB_RHIST   "&JJOB_DIR;/J&CAP_RUN;_RHIST">
-<!ENTITY exSCR_RHIST  "&SCRIPT_DIR;/&RUN;/ex&RUN;_rhist.ksh">
+<!ENTITY JJOB_RHIST      "&JJOB_DIR;/J&CAP_RUN;_RHIST">
+<!ENTITY exSCR_RHIST     "&SCRIPT_DIR;/&RUN;/ex&RUN;_rhist.ksh">
+<!ENTITY JJOB_NCDIAG     "&JJOB_DIR;/J&CAP_RUN;_NCDIAG">
+<!ENTITY exSCR_NCDIAG    "&SCRIPT_DIR;/ex&NET;_ncdiag.ksh">
 <!ENTITY JJOB_CLEAN     "&JJOB_DIR;/J&CAP_RUN;_CLEAN">
 <!ENTITY exSCR_CLEAN    "&SCRIPT_DIR;/ex&NET;_clean.ksh">
 
@@ -278,19 +282,22 @@
 <!ENTITY PRDGEN_RESOURCES '<walltime>00:30:00</walltime>'>
 <!ENTITY PRDGEN_RESERVATION '<nodes>1:ppn=128:mem=256GB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
+<!ENTITY NCDIAG_PROC "1">
+<!ENTITY NCDIAG_RESOURCES '<walltime>00:15:00</walltime>'>
+<!ENTITY NCDIAG_RESERVATION '<nodes>1:ppn=8:mem=64GB</nodes><native>-l place=scatter:shared,select=1:ncpus=8:mem=64GB:prepost=true</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
+
 <!ENTITY CLEAN_PROC "1">
 <!ENTITY CLEAN_RESOURCES '<walltime>00:30:00</walltime>'> 
 <!ENTITY CLEAN_RESERVATION '<nodes>1:ppn=1:vntype=cray_compute:mem=4GB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
-
 
 <!-- Variables in Namelist -->
 <!ENTITY GSI_grid_ratio_in_var       "1">
 <!ENTITY GSI_grid_ratio_in_cldanl    "1">
 <!ENTITY i_gsdsfc_uselist            "2">
 <!ENTITY VERBOSE_GSI                 ".false.">
+<!ENTITY READIN_LOCALIZATION         "TRUE">
 
 <!--Retention time for COM and DATA directories-->
-
 <!ENTITY CLEAN_OLDCOM_HRS            "120">
 <!ENTITY CLEAN_OLDRUN_HRS            "72">
 
@@ -571,8 +578,8 @@
       <value><cyclestr>&DATA_PRDGEN;</cyclestr></value>
    </envar>
    <envar>
-     <name>DATA_RHIST</name>
-     <value><cyclestr>&DATA_RHIST;</cyclestr></value>
+      <name>DATA_NCDIAG</name>
+      <value><cyclestr>&DATA_NCDIAG;</cyclestr></value>
    </envar>
    <envar>
       <name>DATA_AUTOQC</name>
@@ -581,6 +588,10 @@
    <envar>
       <name>DATA_OBSPRD</name>
       <value><cyclestr>&DATA_OBSPRD;</cyclestr></value>
+   </envar>
+   <envar>
+      <name>DATA_RHIST</name>
+      <value><cyclestr>&DATA_RHIST;</cyclestr></value>
    </envar>
    <envar>
       <name>DATA_OBSPREP_LGHTN</name>
@@ -726,6 +737,10 @@
       <value>&VERBOSE_GSI;</value>
     </envar>
     <envar>
+      <name>RUN_NCDIAG</name>
+      <value>&RUN_NCDIAG;</value>
+    </envar>
+    <envar>
       <name>i_gsdsfc_uselist</name>
       <value>&i_gsdsfc_uselist;</value>
     </envar>
@@ -857,6 +872,24 @@
       <value>&JJOB_PRDGEN;</value>
     </envar>'>
 
+<!ENTITY ENVARS_NCDIAG
+    '<envar>
+      <name>START_TIME</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>RUN_NCDIAG</name>
+      <value>&RUN_NCDIAG;</value>
+    </envar>
+    <envar>
+      <name>JJOB_NCDIAG</name>
+      <value>&JJOB_NCDIAG;</value>
+    </envar>
+    <envar>
+      <name>exSCR_NCDIAG</name>
+      <value>&exSCR_NCDIAG;</value>
+    </envar>'>
+
 <!ENTITY ENVARS_AUTOQC
     '<envar>
       <name>START_TIME</name>
@@ -975,7 +1008,7 @@
       <value>&CLEAN_OLDRUN_HRS;</value>
     </envar>
     <envar>
-      <name>CLEAN_OLDCOM_HRS</name>  
+      <name>CLEAN_OLDCOM_HRS</name>
       <value>&CLEAN_OLDCOM_HRS;</value>
     </envar>
     <envar>
@@ -1099,7 +1132,6 @@
     &OBSPREP_RADAR_RESOURCES;
     &OBSPREP_RADAR_RESERVATION;
     &ENVARS_PREPJOB;
-
 
     <dependency>
       <or>
@@ -1225,7 +1257,6 @@
        <value><cyclestr>&DATA_GSIANL;</cyclestr></value>
     </envar>
 
-
     <command>&JJOB_DIR;/launch.ksh &JJOB_GSIANL;</command>
     <jobname><cyclestr>&RUN;_gsianl_job_@Y@m@d@H@M</cyclestr></jobname>
     <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_gsianl_@Y@m@d@H.log</cyclestr></join>
@@ -1243,6 +1274,27 @@
       </and>
      </dependency>
   </task>
+
+  <task name="&RUN;_ncdiag_task" cycledefs="hourly" maxtries="&maxtries;">
+       
+    &ENVARS;
+    &NCDIAG_RESOURCES;
+    &NCDIAG_RESERVATION;
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_NCDIAG;</cyclestr></value>
+    </envar>
+
+    <command>&JJOB_DIR;/launch.ksh &JJOB_NCDIAG;</command>
+    <jobname><cyclestr>&RUN;_ncdiag_job_@Y@m@d@H@M</cyclestr></jobname>
+    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_ncdiag_@Y@m@d@H.log</cyclestr></join>
+
+    &ENVARS_NCDIAG;
+
+    <dependency>
+          <taskdep task="&RUN;_gsianl_task"/>
+    </dependency>
+    </task>
 
   <task name="&RUN;_anldump_task" cycledefs="hourly" maxtries="&maxtries;">
     &ENVARS;
@@ -1326,7 +1378,6 @@
       </and>
     </dependency>
   </task>
-
 
   <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
 

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -110,6 +110,7 @@
 <!ENTITY DATA_POSTSND   "&DATA_RUNDIR;/wrfbufr">
 <!ENTITY DATA_RHIST     "&DATA_RUNDIR;/rhist">
 <!ENTITY DATA_HRRRDAS   "&DATA_RUNDIR;/hrrrdas">
+<!ENTITY DATA_NCDIAG    "&DATA_RUNDIR;/ncdiagprd">
 
 <!ENTITY hpsspath0      "/NCEPDEV/emc-meso/5year/&USER;/pbspro_rtma3d">
 <!ENTITY hpsspath1      "/NCEPPROD/hpssprod/runhistory">
@@ -138,6 +139,7 @@
 <!ENTITY SENDCOM	"YES">
 <!ENTITY RUN_RHIST	"No">
 <!ENTITY RUN_HOWV	"No">
+<!ENTITY RUN_NCDIAG	"Yes">
 
 <!-- for various observations used in RTMA3D -->
 
@@ -193,10 +195,12 @@
 <!ENTITY JJOB_POST4FGS   "&JJOB_DIR;/J&CAP_RUN;_POST4FGS">
 <!ENTITY exSCR_POST4FGS  "&SCRIPT_DIR;/ex&RUN;_post4fgs.ksh">
 <!ENTITY JJOB_PRDGEN     "&JJOB_DIR;/J&CAP_RUN;_PRDGEN">
-<!ENTITY JJOB_RHIST   "&JJOB_DIR;/J&CAP_RUN;_RHIST">
-<!ENTITY exSCR_RHIST  "&SCRIPT_DIR;/&RUN;/ex&RUN;_rhist.ksh">
-<!ENTITY JJOB_HRRRDAS   "&JJOB_DIR;/J&CAP_RUN;_HRRRDAS">
-<!ENTITY exSCR_HRRRDAS  "&SCRIPT_DIR;/&RUN;/ex&RUN;_hrrrdas.ksh">
+<!ENTITY JJOB_RHIST      "&JJOB_DIR;/J&CAP_RUN;_RHIST">
+<!ENTITY exSCR_RHIST     "&SCRIPT_DIR;/&RUN;/ex&RUN;_rhist.ksh">
+<!ENTITY JJOB_HRRRDAS    "&JJOB_DIR;/J&CAP_RUN;_HRRRDAS">
+<!ENTITY exSCR_HRRRDAS   "&SCRIPT_DIR;/&RUN;/ex&RUN;_hrrrdas.ksh">
+<!ENTITY JJOB_NCDIAG     "&JJOB_DIR;/J&CAP_RUN;_NCDIAG">
+<!ENTITY exSCR_NCDIAG    "&SCRIPT_DIR;/ex&NET;_ncdiag.ksh">
 
 <!-- Resources -->
 
@@ -284,6 +288,10 @@
 <!ENTITY PRDGEN_PROC "1">
 <!ENTITY PRDGEN_RESOURCES '<walltime>00:30:00</walltime>'>
 <!ENTITY PRDGEN_RESERVATION '<nodes>1:ppn=128:mem=48GB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
+
+<!ENTITY NCDIAG_PROC "1">
+<!ENTITY NCDIAG_RESOURCES '<walltime>00:30:00</walltime>'>
+<!ENTITY NCDIAG_RESERVATION '<nodes>1:ppn=6:mem=96GB</nodes><native>-l place=vscatter:shared:prepost=true</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
 <!-- Variables in Namelist -->
 <!ENTITY GSI_grid_ratio_in_var       "1">
@@ -568,6 +576,10 @@
       <value><cyclestr>&DATA_PRDGEN;</cyclestr></value>
    </envar>
    <envar>
+      <name>DATA_NCDIAG</name>
+      <value><cyclestr>&DATA_NCDIAG;</cyclestr></value>
+   </envar>
+   <envar>
       <name>DATA_AUTOQC</name>
       <value><cyclestr>&DATA_AUTOQC;</cyclestr></value>
    </envar>
@@ -743,6 +755,10 @@
       <value>&VERBOSE_GSI;</value>
     </envar>
     <envar>
+      <name>RUN_NCDIAG</name>
+      <value>&RUN_NCDIAG;</value>
+    </envar>
+    <envar>
       <name>i_gsdsfc_uselist</name>
       <value>&i_gsdsfc_uselist;</value>
     </envar>
@@ -872,6 +888,24 @@
     <envar>
       <name>JJOB_PRDGEN</name>
       <value>&JJOB_PRDGEN;</value>
+    </envar>'>
+
+<!ENTITY ENVARS_NCDIAG
+    '<envar>
+      <name>START_TIME</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>RUN_NCDIAG</name>
+      <value>&RUN_NCDIAG;</value>
+    </envar>
+    <envar>
+      <name>JJOB_NCDIAG</name>
+      <value>&JJOB_NCDIAG;</value>
+    </envar>
+    <envar>
+      <name>exSCR_NCDIAG</name>
+      <value>&exSCR_NCDIAG;</value>
     </envar>'>
 
 <!ENTITY ENVARS_AUTOQC
@@ -1232,6 +1266,27 @@
       </and>
      </dependency>
   </task>
+
+  <task name="&NET;_ncdiag_task" cycledefs="hourly" maxtries="&maxtries;">
+       
+    &ENVARS;
+    &NCDIAG_RESOURCES;
+    &NCDIAG_RESERVATION;
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_NCDIAG;</cyclestr></value>
+    </envar>
+
+    <command>&JJOB_DIR;/launch.ksh &JJOB_NCDIAG;</command>
+    <jobname><cyclestr>&RUN;_ncdiag_job_@Y@m@d@H@M</cyclestr></jobname>
+    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_ncdiag_@Y@m@d@H.log</cyclestr></join>
+
+    &ENVARS_NCDIAG;
+
+    <dependency>
+          <taskdep task="&RUN;_gsianl_task"/>
+    </dependency>
+    </task>
 
  <task name="&RUN;_hrrrdas_task" cycledefs="hourly" maxtries="&maxtries;">
        &ENVARS;

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -136,7 +136,7 @@
 <!ENTITY maxtries	"3">
 <!ENTITY KEEPDATA	"YES">
 <!ENTITY SENDCOM	"YES">
-<!ENTITY RUN_RHIST	"YES">
+<!ENTITY RUN_RHIST	"No">
 <!ENTITY RUN_HOWV	"No">
 
 <!-- for various observations used in RTMA3D -->

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -20,7 +20,6 @@
 <!ENTITY model		"&RUN;">
 <!ENTITY HRRRDAS_BEC     "1">
 <!ENTITY HRRRDAS_CUTOFF  "32">
-<!ENTITY READIN_LOCALIZATION     "TRUE">
 
 <!ENTITY MACHINE	"cray">
 <!ENTITY machine	"&MACHINE;">
@@ -131,9 +130,7 @@
 <!ENTITY HOMEBASE_DIR	"&NWROOT;">
 <!ENTITY DATABASE_DIR	"&ptmp_base;">
 
-
 <!-- for workflow -->
-
 <!ENTITY maxtries	"3">
 <!ENTITY KEEPDATA	"YES">
 <!ENTITY SENDCOM	"YES">
@@ -293,7 +290,7 @@
 
 <!ENTITY NCDIAG_PROC "1">
 <!ENTITY NCDIAG_RESOURCES '<walltime>00:30:00</walltime>'>
-<!ENTITY NCDIAG_RESERVATION '<nodes>1:ppn=6:mem=96GB</nodes><native>-l place=vscatter:shared:prepost=true</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
+<!ENTITY NCDIAG_RESERVATION '<nodes>1:ppn=8:mem=64GB</nodes><native>-l place=scatter:shared,select=1:ncpus=8:mem=64GB:prepost=true</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
 <!ENTITY CLEAN_PROC "1">
 <!ENTITY CLEAN_RESOURCES '<walltime>00:30:00</walltime>'> 
@@ -304,13 +301,11 @@
 <!ENTITY GSI_grid_ratio_in_cldanl    "1">
 <!ENTITY i_gsdsfc_uselist            "2">
 <!ENTITY VERBOSE_GSI                 ".false.">
+<!ENTITY READIN_LOCALIZATION         "TRUE">
 
 <!-- COM and DATA retention time (hours) -->
-
 <!ENTITY CLEAN_OLDCOM_HRS            "120">
 <!ENTITY CLEAN_OLDRUN_HRS            "72">
-
-
 
 <!ENTITY NCKS '/apps/prod/nco/4.7.9/cce/11.0.2/bin/ncks'>
 <!-- Block of Variables passed to workflow and tasks -->
@@ -1050,7 +1045,7 @@
       <value>&FCST_LENGTH;</value>
     </envar>'>
 
-    <!ENTITY ENVARS_CLEAN
+<!ENTITY ENVARS_CLEAN
     '<envar>
       <name>CLEAN_OLDRUN_HRS</name>
       <value>&CLEAN_OLDRUN_HRS;</value>
@@ -1084,7 +1079,7 @@
   <cycledef group="rap_e">0 01-11,13-23 * 01-12 2022-2025 *</cycledef>
 
   <cycledef group="rap">0 0,12 * 01-12 2022-2025 *</cycledef>
-  
+
   <cycledef group="3hours">0 */3 * 01-12 2022-2025 *</cycledef>
 
   <task name="&RUN;_clean_task" cycledefs="hourly" maxtries="&maxtries;">
@@ -1094,7 +1089,7 @@
     <command>&JJOB_DIR;/launch.ksh &JJOB_CLEAN;</command>
     <jobname><cyclestr>&RUN;_clean_job_@Y@m@d@H@M</cyclestr></jobname>
     <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_clean_@Y@m@d@H.log</cyclestr></join>
-     
+    
     &CLEAN_RESOURCES;
     &CLEAN_RESERVATION;
     &ENVARS_CLEAN;
@@ -1310,7 +1305,7 @@
      </dependency>
   </task>
 
-  <task name="&NET;_ncdiag_task" cycledefs="hourly" maxtries="&maxtries;">
+  <task name="&RUN;_ncdiag_task" cycledefs="hourly" maxtries="&maxtries;">
        
     &ENVARS;
     &NCDIAG_RESOURCES;
@@ -1349,6 +1344,7 @@
         <taskdep task="&RUN;_gsianl_task"/>
        </dependency>
   </task>
+
   <task name="&RUN;_anldump_task" cycledefs="hourly" maxtries="&maxtries;">
     &ENVARS;
     <envar>
@@ -1432,7 +1428,7 @@
     </dependency>
   </task>
 
- <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
+  <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
 
     &ENVARS;
     &UPDATEVARS_RESOURCES;
@@ -1476,7 +1472,6 @@
 
     &ENVARS_POST;
 
-
     <dependency> 
           <taskdep task="&RUN;_updatevars_task"/>
     </dependency>
@@ -1501,7 +1496,7 @@
     <dependency> 
           <taskdep task="&RUN;_updatevars_task"/>
     </dependency>
-    </task> 
+  </task>
 
   <task name="&NET;_prdgen_task" cycledefs="hourly" maxtries="&maxtries;">
        


### PR DESCRIPTION
1. To save the wall-clock time of GSI analysis task, the step to combine the netcdf-format obs-diag files was removed (which typically adds over 15 mins into the wall-clock time of whole GSI task). But using netcdf-format obs-diag file is encouraged for the advantages of netcdf format files. So the step of concatenating netcdf obs-diag files in GSI script was taken out and put into a separate script. And by using CFP to run multiple concatenation tasks simultaneously, the wall-clock time of this step is less than 5 mins (~ 3 min in average);
2. the decorrelation length scale factors (hzscl and vs) could be easily tuned/changed in gsi analysis script;
3. adding namelist file (namelist.conv) for running rtma3d_read_diag in autoqc.ksh;
4. fixed a few minor bugs;