### PR TITLE
Fixed bugs with thinning hrrrdas ensemble and radar radial wind filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,16 @@ workflow/*.log
 *.x
 *.exe
 sorc/**/*.mod
+sorc/rtma3d_obslist.fd/rtma3d_obslist
+sorc/rtma3d_process_cloud.fd/rtma3d_process_cloud
+sorc/rtma3d_process_lightning.fd/rtma3d_process_lightning
+sorc/rtma3d_process_mosaic.fd/rtma3d_process_mosaic
+sorc/rtma3d_process_mosaic.fd/rtma3d_process_mosaic_enkf
+sorc/rtma3d_smartinit.fd/rtma3d_smartinit
+sorc/rtma3d_sndp.fd/rtma3d_sndp
+sorc/rtma3d_stnmlist.fd/rtma3d_stnmlist
+sorc/rtma3d_wrfbufr_alaska.fd/rtma3d_wrfbufr_alaska
+sorc/rtma3d_wrfbufr_conus.fd/rtma3d_wrfbufr_conus
 #
 #  # ignore directory of gsi and post(upp) source code ('sorc/rtma_gsi.fd, sorc/rtma_post.fd')
 #

--- a/scripts/akrtma3d/exakrtma3d_gsianl.ksh
+++ b/scripts/akrtma3d/exakrtma3d_gsianl.ksh
@@ -111,7 +111,7 @@ else
 fi
 
 if [ -r "${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d" ]; then
-  ${LN} -sf ${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d ./nexradbufr
+  ${LN} -sf ${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d ./l2rwbufr
 else
   ${ECHO} "Warning: ${OBS_DIR}: nexrad does not exist!"
 fi

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -106,7 +106,8 @@ else
 fi
 
 if [ -r "${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d" ]; then
-  ${LN} -sf ${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d ./nexradbufr
+# ${LN} -sf ${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d ./nexradbufr         #<--- wrong fname
+  ${LN} -sf ${OBS_DIR}/${NET}.t${cyc}z.nexrad.tm00.bufr_d ./l2rwbufr           #<--- correct fname
 else
   ${ECHO} "Warning: ${OBS_DIR}: nexrad does not exist!"
 fi
@@ -192,6 +193,21 @@ if [ ${HRRRDAS_BEC} -eq 1 ]; then
    ${LN} -sf ${hrrre_file} wrf_en0${cc}
    ((c = c + 1))
   done
+elif [ ${HRRRDAS_BEC} -eq 2 ]; then
+  ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_BEC}, so the thinned-HRRRDAS will be used if available"
+  #----------------------------------------------------
+  # generate list of HRRRDAS members for ensemble covariances
+  # Use 1-hr forecasts from the HRRRDAS cycling
+  rm -f ./filelist.hrrrdas
+  c=1
+  while [[ $c -le 36 ]]; do
+   cc=$(printf "%02d" $c)
+#  hrrre_file=${COMINhrrrdas}/hrrrdas_small_d02_${time_1hour_ago}00f01_mem00${cc}
+   hrrre_file=${COMOUT}/hrrrdas.t${cyc}z/hrrrdas_small_d02_${time_1hour_ago}00f01_mem00${cc}_thinned
+   ${LS} ${hrrre_file} >> filelist.hrrrdas
+   ${LN} -sf ${hrrre_file} wrf_en0${cc}
+   ((c = c + 1))
+  done
 else
   ${ECHO} "\$HRRRDAS_BEC=${HRRRDAS_BEC}, so HRRRDAS will NOT be used"
   ${TOUCH} filelist.hrrrdas #so as to avoid "no such file" error message
@@ -205,7 +221,7 @@ nummem=`more filelist03 | wc -l`
 nummem=$((nummem - 3 ))
 hrrrmem=`more filelist.hrrrdas | wc -l`
 hrrrmem=$((hrrrmem - 3 ))
-if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC is available, use it as first choice
+if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -ge 1  ]]; then #if HRRRDAS BEC is available, use it as first choice
   echo "Do hybrid with HRRRDAS BEC"
   EnsWgt=0.9
   nummem=${hrrrmem}

--- a/scripts/rtma3d/exrtma3d_hrrrdas.ksh
+++ b/scripts/rtma3d/exrtma3d_hrrrdas.ksh
@@ -75,19 +75,17 @@ exit 0
 fi
 
 mem_varlist="T,P_TOP,MU,MUB,U,V,QVAPOR,ZNW,Times,TH2,Q2,U10,V10"
-c=1
+c=0
 while IFS= read -r line
 do
-  while [[ $c -le 36 ]]; do
-    if [ $c -lt 10 ]; then
-       cc="0"$c
-    else
-       cc=$c
-    fi
-  ncks -A -v ${mem_varlist} $line $DATA/hrrrdas_small_d02_${PDYHH_cycm1}00f01_mem00${cc}_thinned 
-  cp $DATA/hrrrdas_small_d02_${PDYHH_cycm1}00f01_mem00${cc}_thinned ${COMOUThrrrdas_rtma3d}
-  c=$(($c + 01 ))
-  done
+  let "c=c+1"
+  cc=`printf "%02d" $c`
+  fname_thinned="hrrrdas_small_d02_${PDYHH_cycm1}00f01_mem00${cc}_thinned"
+  echo "for member $cc original ensemble file: $line "
+  rm -f $DATA/${fname_thinned}
+# ncks -A -v ${mem_varlist} $line $DATA/${fname_thinned}        # -A: append, but miss Global Attributes. Datasets are the same.
+  ncks    -v ${mem_varlist} $line $DATA/${fname_thinned}
+  cp -p $DATA/${fname_thinned}    ${COMOUThrrrdas_rtma3d}
 done < "$filename"
 
 exit 0

--- a/sorc/build_rtma3d_gsi.sh
+++ b/sorc/build_rtma3d_gsi.sh
@@ -37,8 +37,15 @@ case "${GSI_SOURCE}" in
         git clone https://github.com/NOAA-EMC/GSI.git  ./rtma3d_gsi.fd
         cd ${BASE}/rtma3d_gsi.fd
         echo "git checkout develop"
-        git checkout develop       # <--- checking out the latest commit of develop branch
-#       git checkout 0ef8d87       # <--- specifying the commit
+#       git checkout develop       # <--- checking out the latest commit of develop branch
+        git checkout 964bcc3       # <--- specifying the commit
+                                   # commit 964bcc3 is the old commit which still works with netcdf 4.7.r42
+                                   # and does not need to load hdf5 lib when building and running GSI.
+                                   # After this commit (from commit 2ddc1ac), GSI, by default,
+                                   # uses bufr v12, netcdf 4.9.2 (require loading hdf5 lib), IP lib 5.x.
+                                   # So need to update the module files when building and running 3DRTMA package.
+                                   # After further testing with new GSI, the new modules would be updated
+                                   # in 3DRTMA pacakge.
         ;;
     auto?([-_])qc|Auto?([-_])QC )
         echo "git clone https://github.com/MatthewMorris-NOAA/GSI.git ./rtma3d_gsi.fd  # GSI_SOURCE=${GSI_SOURCE}"

--- a/workflow/launch.ksh
+++ b/workflow/launch.ksh
@@ -192,6 +192,7 @@ export BC=/usr/bin/bc
 export WHICH=/usr/bin/which
 export GREP=/usr/bin/grep
 export UNZIP=/bin/unzip
+export TOUCH=/usr/bin/touch
 
 else
   echo "modulefile has not set up for this unknow machine. Job abort!"


### PR DESCRIPTION
1. fixed a bug in exrtma3d_hrrrdas.ksh, so that each thinned ensemble member is generated with the correct corresponding original ensemble member;
2. fixed the typo in radar radial obs wind filename (l2rwbufr) in gsianl.ksh;
3. add control in gsianl.ksh, so user can choose either use original hrrrdas ensemble(set HRRRDAS_BEC=1 in rtma3d_pbspro_conus.xml workflow file), or use the thinned ensemble (HRRRDAS_BEC=2)

I ran the gsi analysis with original HRRRDAS ensemble and the thinned ensemble at several analysis cycles
20250710_1400Z: analysis results are same
20250710_2100Z: analysis results are **not** same
20250713_1300Z: analysis results are same
20250713_1400Z: analysis results are same
20250713_1500Z: analysis results are same
20250713_1600Z: analysis results are same
20250713_1700Z: analysis results are same
20250713_1800Z: analysis results are same 

The results should be identical. And I only found for one cycle the results are not same. After checking the results, the reason seems not be related to the thinned ensemble. So the thinned ensemble should be good.
