### PR TITLE
Updates of checking file size of firstguess and a few more 

### DIFF
--- a/jobs/JRTMA3D_ANLDUMP
+++ b/jobs/JRTMA3D_ANLDUMP
@@ -93,6 +93,10 @@ export COMINsice=${COMINsice:-$(compath.py prod/seaice_analysis/${seaice_analysi
 ### 3DRTMA GSIANL Products (netcdf)
 export COMOUTgsi_rtma3d=${COMOUTgsi_rtma3d:-"${COMOUT}/gsiprd.${cycle}"}
 
+#   DATA_SHARED: the sub-directory to share the data
+#     (where the GSI analysis file, wrf_inout, is saved)
+export DATA_SHARED=${DATA_SHARED:-"${DATA_RUNDIR}/sharedprd"}
+
 # Directory to store the firstguess as input for the RTMA3D (NETCDF?) 
 
 export GESINhrrr_rtma3d=${GESINhrrr_rtma3d:-"${COMIN}/fgsprd.${cycle}"}

--- a/jobs/JRTMA3D_CLEAN
+++ b/jobs/JRTMA3D_CLEAN
@@ -45,6 +45,19 @@ export HOMErtma3d=${HOMErtma3d:-$NWROOT/rtma.${rtma_ver}}
 # date and time for previous and next cycle
 export PDYHH="${PDY}${cyc}"
 
+# creating a sub-directory under top running directory to share the data among various steps
+#   DATA_RUNDIR: the top running directory
+export DATA_RUNDIR=${DATA_RUNDIR:-"${DATAROOT}/${envir}/${NET}.${PDY}${cyc}"}
+if [ ! -d "${DATA_RUNDIR}" ] ; then
+    mkdir -p ${DATA_RUNDIR}
+fi
+#   DATA_SHARED: the sub-directory to share the data
+export DATA_SHARED=${DATA_SHARED:-"${DATA_RUNDIR}/sharedprd"}
+if [ ! -d "${DATA_SHARED}" ] ; then
+    mkdir -p ${DATA_SHARED}
+fi
+
+# running the executable script
 ${exSCR_CLEAN:-$HOMErtma3d/scripts/ex${NET}_clean.ksh}
 export err=$?; err_chk
 

--- a/jobs/JRTMA3D_GSIANL
+++ b/jobs/JRTMA3D_GSIANL
@@ -163,6 +163,12 @@ if [ "${envir}" != "esrl" ]; then #WCOSS
         ${RM} -rf ${DATAHOME_BK}
     fi
     ${LN} -s  ${GESINhrrr_rtma3d}  ${DATAHOME_BK}
+
+#   DATA_SHARED: the sub-directory to share the data
+    export DATA_SHARED=${DATA_SHARED:-"${DATA_RUNDIR}/sharedprd"}
+    if [ ! -d "${DATA_SHARED}" ] ; then
+        mkdir -p ${DATA_SHARED}
+    fi
 fi
 
 #   Set the path to the GSI static files

--- a/jobs/JRTMA3D_NCDIAG
+++ b/jobs/JRTMA3D_NCDIAG
@@ -118,8 +118,14 @@ if [ "${envir}" != "esrl" ]; then #WCOSS
 #   Set the path (DATAGSIHOME) to gsi running directory
 #       where the original netcdf format obs-diag files (not combined yet) are generated in GSI run
     export DATAGSIHOME=${DATA_RUNDIR}/gsiprd
-    if [ ! -d "${DATAGSIHOME}" ] ; then
-       echo " Directory of GSI running data does NOT exist. Job abort!"
+
+#   DATA_SHARED: the sub-directory to share the data
+    export DATA_SHARED=${DATA_SHARED:-"${DATA_RUNDIR}/sharedprd"}
+
+#   DATAGSI: the directory where the split obs-diag nc4 files are saved
+    export DATAGSI=${DATA_SHARED:-"${DATAGSIHOME}"}
+    if [ ! -d "${DATAGSI}" ] ; then
+       echo " Directory(where the gsi obs-diag nc4 files are saved) does not exist. Job abort!"
        err_exit
     fi
 

--- a/jobs/JRTMA3D_UPDATEVARS
+++ b/jobs/JRTMA3D_UPDATEVARS
@@ -129,18 +129,22 @@ if [ "${envir}" != "esrl" ]; then #WCOSS
     if [ ! -d "${DATA_RUNDIR}" ] ; then
         mkdir -p ${DATA_RUNDIR}
     fi
-    export DATAHOME=${DATA_RUNDIR}/gsiprd
-#    ${RM} -rf ${DATAHOME}
-#    ${LN} -s  ${DATA}  ${DATAHOME}
+
+#    wrfprd : the updatevars working directory (model 1-step forecast) 
+    export DATAHOME=${DATA_WRFPRD:-"${DATA_RUNDIR}/wrfprd"}
+    if [ -L "${DATAHOME}" ] && [ -d "${DATAHOME}" ] ; then
+        ${RM} -rf ${DATAHOME}
+    fi
+    ${LN} -s  ${DATA}  ${DATAHOME}
+
+    export DATAHOME_ANL=${DATA_RUNDIR}/gsiprd
 
     export DATAOBSHOME=${DATA_RUNDIR}/obsprd
 
-#    ${RM} -rf ${DATAOBSHOME}
-#    ${LN} -s  ${COMINobsproc_rtma3d}  ${DATAOBSHOME}
-
     export DATAHOME_BK=${DATA_RUNDIR}/fgsprd
-#    ${RM} -rf ${DATAHOME_BK}
-#    ${LN} -s  ${GESINhrrr_rtma3d}  ${DATAHOME_BK}
+
+#   DATA_SHARED: the sub-directory to share the data
+    export DATA_SHARED=${DATA_SHARED:-"${DATA_RUNDIR}/sharedprd"}
 
 fi
 

--- a/jobs/JRTMA3D_UPDATEVARS
+++ b/jobs/JRTMA3D_UPDATEVARS
@@ -30,6 +30,19 @@ export MPIRUN=${MPIRUN:-"mpirun"}
 
 export CNVGRIB=${CNVGRIB:-cnvgrib}
 
+##########################################################
+# make temp/running directories
+##########################################################
+export DATA=${DATA:-$DATAROOT/${jobid:?}} #jobid ($job.$LSB_JOBID MUST BE DEFINED IN TERMS OF $RUN IN UPPER LEVEL SCRIPT /MPondeca, 26Jul2015
+if [ -d $DATA ] ; then
+   ${ECHO} "$DATA exists, remove its content"
+     ${RM} -rf $DATA/*
+else
+   ${ECHO} "$DATA does not exist, create it"
+   ${MKDIR} -p $DATA
+fi
+cd $DATA
+
 #####################################################
 # Run setpdy and initialize PDY variables
 #    setpdy.sh needs the variables 
@@ -124,7 +137,7 @@ if [ "${envir}" != "esrl" ]; then #WCOSS
       export FGSrtma3d_FNAME="${PROD_HEAD}.firstguess.nc"
     fi
 
-#   Set the path to the working/obs/ges directories
+#   Define the symbolic link path to the working/obs/ges directories
     export DATA_RUNDIR=${DATA_RUNDIR:-"${DATAROOT}/${envir}/${NET}.${PDY}${cyc}"}
     if [ ! -d "${DATA_RUNDIR}" ] ; then
         mkdir -p ${DATA_RUNDIR}

--- a/scripts/akrtma3d/exakrtma3d_anldump.ksh
+++ b/scripts/akrtma3d/exakrtma3d_anldump.ksh
@@ -24,11 +24,14 @@ check_dirs_exist() { #usage: check_dirs_exist "var1_name" "var2_name" ...
   check_if_defined "COMOUTgsi_rtma3d"
   check_dirs_exist "COMOUTgsi_rtma3d"
   check_if_defined "ANLrtma3d_FNAME"
+  check_if_defined "DATA_SHARED"
+  check_dirs_exist "DATA_SHARED"
 #  checking the directory where firstguess file (grib2) of howv/gust/vis is saved
   check_if_defined "COMOUT"
   check_dirs_exist "COMOUT"
 
-  ncf_anl=${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+# ncf_anl=${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+  ncf_anl=${DATA_SHARED}/wrf_inout
 
 #############################################################################
 # Make sure START_TIME is defined and in the correct format

--- a/scripts/akrtma3d/exakrtma3d_gsianl.ksh
+++ b/scripts/akrtma3d/exakrtma3d_gsianl.ksh
@@ -811,13 +811,10 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
 #    follow-up updatevars step, this analysis file is only copied to the Shared directory (sharedprd).
 #    The final file wrf_inout would be copied to COM2 at the end of updatevars step after it is finalized.
 # ${CP} -p ${DATA}/wrf_inout                   ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
-# ${CP} -p ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # copying big file takes time
-  ${MV}    ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # using "mv" to save time
-  ${LN} -sf ${DATA_SHARED}/wrf_inout           ${DATA}/wrf_inout        # linking wrf_inout back to analysis directory (as a back-up)
-
-# copy the split obs-diag files (nc4) to shared directory (for the follow-up ncdiag step)
-# ${CP} -p {DATA}/pe*.nc4                      ${DATA_SHARED}           # copying takes time
-  ${MV}    {DATA}/pe*.nc4                      ${DATA_SHARED}           # moving  saves time
+  ${CP} -p ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # copying big file takes time
+#    if need to save the wall-clock time of this scipt, use the following two lines (moving instead of copying)
+# ${MV}    ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # using "mv" to save time
+# ${LN} -sf ${DATA_SHARED}/wrf_inout           ${DATA}/wrf_inout        # linking wrf_inout back to analysis directory (as a back-up)
 
   tar -cvf obsfit_fort220_${cycle_str}.tar     ./fort.* ./fit_* ./stdout* ./minimization_fort220.${cycle_str}
   ${CP} -p obsfit_fort220_${cycle_str}.tar     ${COMOUTgsi_rtma3d}
@@ -832,10 +829,37 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
   ${CP} -p hybens_info                         ${COMOUTgsi_rtma3d}
   ${CP} -p stdout                              ${COMOUTgsi_rtma3d}
   ${CP} -p OUTPUT*                             ${COMOUTgsi_rtma3d}
-#  extra backup (NOT necessary)
+#   extra backup (NOT necessary)
 # ${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
 # ${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
 # ${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
+
+#   Copy the split obs-diag files (nc4) to shared directory (for the follow-up ncdiag step)
+# ${MV}    {DATA}/pe*.nc4                      ${DATA_SHARED}           # moving  saves time
+# ${CP} -p {DATA}/pe*.nc4                      ${DATA_SHARED}           # copying thousand small files takes time (6~10 mins)
+#   using cfp command to copy files to save time
+  ncdiag_list=$(ls pe*.nc4)
+  n_files=$(echo ${ncdiag_list} | wc -w)
+  rm -f cp_cfp_cmdfile.txt
+  ic4=0
+  date
+  for f in ${ncdiag_list}
+  do
+    echo "cp -p ${DATA}/${f}  ${DATA_SHARED}/${f}" >> cp_cfp_cmdfile.txt
+    ic4=$((ic4+1))
+  done
+  echo $ic4  ${n_files}
+  echo "========  before copy pe*.nc4 ========================================================="
+  date
+  export exename=cfp
+  export CMDFILE=cp_cfp_cmdfile.txt
+  export nvar=60
+  command="mpiexec -np ${nvar} --cpu-bind verbose,core ${exename} $CMDFILE >> cp_cfp.stdout 2>&1"
+  echo $command
+  $command
+  date
+  echo "========  after  copy pe*.nc4 ========================================================="
+
 fi  
 #${RM} -f ${DATA}/sig*
 #${RM} -f ${DATA}/obs*

--- a/scripts/akrtma3d/exakrtma3d_gsianl.ksh
+++ b/scripts/akrtma3d/exakrtma3d_gsianl.ksh
@@ -192,7 +192,7 @@ nummem=`more filelist03 | wc -l`
 nummem=$((nummem - 3 ))
 hrrrmem=`more filelist.hrrrdas | wc -l`
 hrrrmem=$((hrrrmem - 3 ))
-if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -eq 1  ]]; then #if HRRRDAS BEC is available, use it as first choice
+if [[ ${hrrrmem} -gt 30 ]] && [[ ${HRRRDAS_BEC} -ge 1  ]]; then #if HRRRDAS BEC is available, use it as first choice
   echo "Do hybrid with HRRRDAS BEC"
   EnsWgt=0.9
   nummem=${hrrrmem}
@@ -225,6 +225,18 @@ elif [[ ${nummem} -eq 80 ]]; then
      HYBENS_INFO=${PARMgsi}/hybens_info
      ${CP} ${PARMgsi}/hybens_info hybens_info
   fi
+  # link GDAS ensemble members to the analysis working directory
+  # read gdas ensemble file names (with full path name) in filelist03
+  c=0
+  while read line_mem
+  do
+     let "c=c+1"
+     ccc=$(printf "%03d" $c)
+     en_linkname="ens_mem${ccc}"
+     [[ -f ./${en_linkname} ]] && rm -f ./${en_linkname}
+     echo "linking ${en_linkname}: --> ${line_mem}"
+     ${LN} -sf ${line_mem} ./${en_linkname}
+  done < ./filelist03
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses GDAS directly with n_ens=${nummem}" >> ${pgmout}
 else
   beta1_inv=1.0
@@ -794,22 +806,36 @@ fi ###### second GSI run
                                                               # (saving space, but costing more time)
 
 if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
-  ${CP} -p ${DATA}/wrf_inout                   ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
-  ${CP} -p minimization_fort220.${cycle_str}   ${COMOUTgsi_rtma3d}
-  tar -cvf obsfit_fort220_${cycle_str}.tar     ./fort.* ./fit_* ./stdout*
-  ${CP} -p  obsfit_fort220_${cycle_str}.tar    ${COMOUTgsi_rtma3d}
+
+#  Some variables (reflectivity, etc.) in analysis file (wrf_inout) would be updated in the
+#    follow-up updatevars step, this analysis file is only copied to the Shared directory (sharedprd).
+#    The final file wrf_inout would be copied to COM2 at the end of updatevars step after it is finalized.
+# ${CP} -p ${DATA}/wrf_inout                   ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+# ${CP} -p ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # copying big file takes time
+  ${MV}    ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # using "mv" to save time
+  ${LN} -sf ${DATA_SHARED}/wrf_inout           ${DATA}/wrf_inout        # linking wrf_inout back to analysis directory (as a back-up)
+
+# copy the split obs-diag files (nc4) to shared directory (for the follow-up ncdiag step)
+# ${CP} -p {DATA}/pe*.nc4                      ${DATA_SHARED}           # copying takes time
+  ${MV}    {DATA}/pe*.nc4                      ${DATA_SHARED}           # moving  saves time
+
+  tar -cvf obsfit_fort220_${cycle_str}.tar     ./fort.* ./fit_* ./stdout* ./minimization_fort220.${cycle_str}
+  ${CP} -p obsfit_fort220_${cycle_str}.tar     ${COMOUTgsi_rtma3d}
   tar -cvf misc_info_${cycle_str}.tar  ./*info ./errtable ./prepobs_prep.bufrtable  ./*bias*  \
-    ./current_bad_aircraft ./gsd_sfcobs_uselist.txt ./gsd_sfcobs_provider.txt ./stdout*
-  ${CP} -p  misc_info_${cycle_str}.tar         ${COMOUTgsi_rtma3d}
+    ./current_bad_aircraft ./*sfcobs_uselist* ./gsd_sfcobs_provider.txt ./stdout* ./filelist* \
+    ./OUTPUT*
+  ${CP} -p misc_info_${cycle_str}.tar          ${COMOUTgsi_rtma3d}
+
+  ${CP} -p minimization_fort220.${cycle_str}   ${COMOUTgsi_rtma3d}
   ${CP} -p filelist.hrrrdas 		       ${COMOUTgsi_rtma3d}
   ${CP} -p filelist03                          ${COMOUTgsi_rtma3d}
   ${CP} -p hybens_info                         ${COMOUTgsi_rtma3d}
   ${CP} -p stdout                              ${COMOUTgsi_rtma3d}
   ${CP} -p OUTPUT*                             ${COMOUTgsi_rtma3d}
-  # extra backup (NOT necessary)
-  #${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
-  #${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
-  #${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
+#  extra backup (NOT necessary)
+# ${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
+# ${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
+# ${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
 fi  
 #${RM} -f ${DATA}/sig*
 #${RM} -f ${DATA}/obs*

--- a/scripts/akrtma3d/exakrtma3d_prepfgs.ksh
+++ b/scripts/akrtma3d/exakrtma3d_prepfgs.ksh
@@ -87,7 +87,12 @@ CDATE=$PDY$cyc
 ###################################################################################
    found_hrrrges=no
    ic=1
-   while [ $ic -le 9 ] ; do
+   ic_max=9                           # max hours to search back for hrrr forecast file
+   targetsize_hrrr=9092419248         # HRRRv4 on Alaska on WCOSS2 (forecast/restart history file)
+   ics_max=15                         # max times to check the filesize of hrrr forecast
+   sleep_time=60
+#  loop of searching for firstguess in HRRR forecast file
+   while [ $ic -le ${ic_max} ] ; do
      hrrrFHH=$ic
      hrrrFHH=`printf %02d $hrrrFHH`
      hrrrCYCLE=`$NDATE -$hrrrFHH $CDATE`
@@ -98,19 +103,47 @@ CDATE=$PDY$cyc
 #       probe_hrrr_guess_nc=$GESINhrrr/alaska/hrrrak_${hrrrCYCLE}f0${hrrrFHH}
 #       probe_hrrr_guess_nc=$GESINhrrr/hrrrak_${hrrrCYCLE}f0${hrrrFHH}
         export probe_hrrr_guess_nc=hrrrak_${hrrrCYCLE}f0${hrrrFHH}
+        size_match=no
+        found_hrrrges=no
         if [ -s $GESINhrrr/$probe_hrrr_guess_nc ]; then
-#           cpreq $probe_hrrr_guess_nc $COMOUT/${RUN}.t${cyc}z.hrrrak_${hrrrCYCLE}f0${hrrrFHH}
-            cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/
-            cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/${FGSrtma3d_FNAME}
-            ind=$ic
-            PDYHH_AK=$hrrrCYCLE
             found_hrrrges=yes
-           break
+
+            ics=1
+#           loop of checking the filesize of hrrr forecast
+            while [ $ics -le ${ics_max} ] ; do
+                filesize=$(stat -c %s $GESINhrrr/$probe_hrrr_guess_nc)
+                if [[ ${filesize} -eq ${targetsize_hrrr} ]] ; then
+                    size_match="yes"
+#                   cpreq $probe_hrrr_guess_nc $COMOUT/${RUN}.t${cyc}z.hrrrak_${hrrrCYCLE}f0${hrrrFHH}
+#                   cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/
+                    break  # breaking out the loop of checking file size
+                else
+                    size_match="no"
+                    msg="${probe_hrrr_guess_nc} filesize (${filesize}) does not match the standard size (${targetsize_hrrr}). Sleep for 60 seconds and check again ..."
+                    ${ECHO} "${msg}"
+                    sleep ${sleep_time}
+                fi
+                let "ics=ics+1"
+            done
+
+            if [[ ${size_match} =~ [yYtT] ]] ; then
+                cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/${FGSrtma3d_FNAME}
+                ind=$ic
+                PDYHH_AK=$hrrrCYCLE
+                break      # breaking out the loop of searching for firstguess in HRRR forecast
+            else
+                msg="hrrr ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Trying to search in the earlier hrrr forecast files ..."
+                ${ECHO} "${msg}"
+#               cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later
+                cpreq $GESINhrrr/$probe_hrrr_guess_nc ${GESINhrrr_rtma3d}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later
+            fi
          fi
      fi
+
      let "ic=ic+1"
+
    done
-   echo "found_hrrrges: "$found_hrrrges
+   echo "found_hrrrges: "$found_hrrrges  "  size_match: ${size_match}"
 
    if [[ ${found_hrrrges} = no ]] ; then
        err_exit "No HRRR guess available. The missing files are GESINhrrr/alaska/hrrrak__${hrrrCYCLE}f0${hrrrFHH}. The script must be able to find at least one file in the above querying do-while loop"
@@ -644,7 +677,7 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
     if [ -r ${DATA}/${FGSrtma3d_FNAME} ] ; then
 #      ${LN} -sf ${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME}     ${DATA}/${FGSrtma3d_FNAME}
        ${ECHO} "PREPFGS: Saving the Firstguess of Cycle ${YYYYMMDDHH} --> ${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME} "
-       cp -p ${DATA}/${probe_hrrr_guess_nc} ${GESINhrrr_rtma3d}/
+#      cp -p ${DATA}/${probe_hrrr_guess_nc} ${GESINhrrr_rtma3d}/     # ${DATA}/${probe_hrrr_guess_nc} does not exist
        cp -p ${DATA}/${FGSrtma3d_FNAME}     ${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME}    
 
 #      to save the disck space, removing the firstguess file under working directry (fgsprd), 
@@ -661,5 +694,7 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
 export err=$? ; err_chk
 
 ls -l ${GESINhrrr_rtma3d} > ${GESINhrrr_rtma3d}/fgs_data_${PDY}_${cyc}.list
+${ECHO} "===========================" >> ${GESINhrrr_rtma3d}/fgs_data_${PDY}_${cyc}.list
+${ECHO} "${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME} comes originally from ${GESINhrrr}/${probe_hrrr_guess_nc}" >> ${GESINhrrr_rtma3d}/fgs_data_${PDY}_${cyc}.list
 
 exit 0

--- a/scripts/akrtma3d/exakrtma3d_prepfgs.ksh
+++ b/scripts/akrtma3d/exakrtma3d_prepfgs.ksh
@@ -111,7 +111,12 @@ CDATE=$PDY$cyc
             ics=1
 #           loop of checking the filesize of hrrr forecast
             while [ $ics -le ${ics_max} ] ; do
-                filesize=$(stat -c %s $GESINhrrr/$probe_hrrr_guess_nc)
+                if [ -L "$GESINhrrr/$probe_hrrr_guess_nc" ] ; then
+                    realfgsfile=$(readlink -f $GESINhrrr/$probe_hrrr_guess_nc)
+                else
+                    realfgsfile="$GESINhrrr/$probe_hrrr_guess_nc"
+                fi
+                filesize=$(stat -c %s ${realfgsfile})
                 if [[ ${filesize} -eq ${targetsize_hrrr} ]] ; then
                     size_match="yes"
 #                   cpreq $probe_hrrr_guess_nc $COMOUT/${RUN}.t${cyc}z.hrrrak_${hrrrCYCLE}f0${hrrrFHH}
@@ -130,14 +135,30 @@ CDATE=$PDY$cyc
                 cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/${FGSrtma3d_FNAME}
                 ind=$ic
                 PDYHH_AK=$hrrrCYCLE
+                msg="HRRR-AK ${ic}-hour forecast file ${probe_hrrr_guess_nc} is used as the firstguess for analysis cycle at ${PDY} ${cyc}Z"
+                ${ECHO} "${msg}"
+                postmsg "$jlogfile" "$msg"
                 break      # breaking out the loop of searching for firstguess in HRRR forecast
             else
-                msg="hrrr ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Trying to search in the earlier hrrr forecast files ..."
-                ${ECHO} "${msg}"
 #               cpreq $GESINhrrr/$probe_hrrr_guess_nc ${DATA}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later
                 cpreq $GESINhrrr/$probe_hrrr_guess_nc ${GESINhrrr_rtma3d}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later
+                msg="HRRR-AK ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists for analysis cycle at ${PDY} ${cyc}Z, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Try to search in the earlier HRRR-AK forecast files ..."
+                ${ECHO} "${msg}"
+                postmsg "$jlogfile" "$msg"
+                SUBJECT=" ${NET} ${RUN} Warning Email: File Size of Firstguess Does Not Match for analysis cycle at ${PDY} ${cyc}Z"
+                MESSAGE="WARNING: ${msg}"
+                ${ECHO} "${MESSAGE}" | ${MAILX} -s "$SUBJECT" -c "${CC_RECIPIENTS}"  "${TO_RECIPIENTS}"
+#               ${ECHO} "${MESSAGE}" | mail.py   #<-- using this line only when system is delivered to NCO
             fi
-         fi
+        else
+            msg="HRRR-AK ${ic}-hour forecat file ${probe_hrrr_guess_nc} is not available for analysis cycle at ${PDY} ${cyc}Z. Try to search in the earlier HRRR-AK foreast files ... "
+            ${ECHO} "${msg}"
+            postmsg "$jlogfile" "$msg"
+            SUBJECT=" ${NET} ${RUN} Warning Email: Missing Firstguess File for analysis cycle at ${PDY} ${cyc}Z"
+            MESSAGE="WARNING: ${msg}"
+            ${ECHO} "${MESSAGE}" | ${MAILX} -s "$SUBJECT" -c "${CC_RECIPIENTS}"  "${TO_RECIPIENTS}"
+#           ${ECHO} "${MESSAGE}" | mail.py   #<-- using this line only when system is delivered to NCO
+        fi
      fi
 
      let "ic=ic+1"
@@ -179,7 +200,9 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
   grid_specs=${grid_specs_hrrrak}
 #
 # 1.2  fix dir (for slmask.grib2 file)
-  print_info_msg "$VERBOSE" "FIXgsi is $FIXgsi"
+# print_info_msg "$VERBOSE" "FIXgsi is $FIXgsi"   (print_info_msg is only available in RRFS worklfow)
+  info_msg="FIXgsi is $FIXgsi"
+  echo "${info_msg}"
 #
 #  Sea-Land Mask for the correct interpolation of the howv Background.
   rm -f ./slmask.grib2
@@ -195,7 +218,8 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
 #    then dumping out to grib2 file
 # 2.1 Wave Background at Great Lakes
 #
-  print_info_msg "$VERBOSE" "COMINww3GL is $COMINww3GL (Wave background from Great Lakes model)"
+  info_msg="COMINww3GL is $COMINww3GL (Wave background from Great Lakes model)"
+  echo "${info_msg}"
 
    found_ww3gesGL=no
    ic=0
@@ -210,7 +234,8 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
 #
       if [ -s $probe_ww3_GL_guess_grb2 ]; then
 
-         print_info_msg "$VERBOSE" "found wave background for Great Lakes: $probe_ww3_GL_guess_grb2"
+         info_msg="found wave background for Great Lakes: $probe_ww3_GL_guess_grb2"
+         echo "${info_msg}"
          cpreq $probe_ww3_GL_guess_grb2 ww3.guess5.grib2
 #        cp -p $probe_ww3_GL_guess_grb2 ww3.guess5.grib2
          cp -p $probe_ww3_GL_guess_grb2 $COMOUT/glwu.grlr_500m.t${ww3CC_GL}z.grib2     # save for retro run
@@ -238,7 +263,8 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
    fi
 #
 # 2.2 Ocean Waves Background
-  print_info_msg "$VERBOSE" "COMINww3 is $COMINww3 (Wave background from WW3 Ocean Wave model)"
+   info_msg="COMINww3 is $COMINww3 (Wave background from WW3 Ocean Wave model)"
+   echo "${info_msg}"
    found_ww3ges=no
    ic=0
    while [ $ic -le 24 ] ; do
@@ -263,8 +289,10 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
       if [ -s "${probe_ww3_guess_grb2[0]}" ] && \
          [ -s "${probe_ww3_guess_grb2[1]}" ]    ; then
 
-         print_info_msg "$VERBOSE" "found wave background for Arctic: ${probe_ww3_guess_grb2[0]}"
-         print_info_msg "$VERBOSE" "found wave background for Global: ${probe_ww3_guess_grb2[1]}"
+         info_msg="found wave background for Arctic: ${probe_ww3_guess_grb2[0]}"
+         echo "${info_msg}"
+         info_msg="found wave background for Global: ${probe_ww3_guess_grb2[1]}"
+         echo "${info_msg}"
          cpreq ${probe_ww3_guess_grb2[0]} ww3.guess0.grib2
 #        cp -p ${probe_ww3_guess_grb2[0]} ww3.guess0.grib2
          cpreq ${probe_ww3_guess_grb2[1]} ww3.guess1.grib2
@@ -411,7 +439,8 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
       hrrr_guess_grb2=${COMINHRRR}/hrrr.${PRE_YYYYMMDD}/alaska/hrrr.t${PRE_HH}z.wrfprsf0${ind}.ak.grib2    # wrfprs; wrfnat; wrfsfc;
 
       if [[ -f ${hrrr_guess_grb2} ]] ; then 
-         print_info_msg "VERBOSE" "found HRRR-AK ${ind} hour forecast (from ${PRE_YYYYMMDD}_${PRE_HH}Z) grib2 file ${hrrr_guess_grb2} and retrieve 10-m Wind Gust from it: "
+         info_msg="found HRRR-AK ${ind} hour forecast (from ${PRE_YYYYMMDD}_${PRE_HH}Z) grib2 file ${hrrr_guess_grb2} and retrieve 10-m Wind Gust from it: "
+         echo "${info_msg}"
          rm -f ./hrrr_guess.grib2
          ln -sf ${hrrr_guess_grb2}   ./hrrr_guess.grib2
          if [ $ind == 0 ]; then
@@ -550,7 +579,8 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
       hrrr_guess_grb2=${COMINHRRR}/hrrr.${PRE_YYYYMMDD}/alaska/hrrr.t${PRE_HH}z.wrfprsf0${ind}.ak.grib2    # wrfprs; wrfnat; wrfsfc;
 
       if [[ -f ${hrrr_guess_grb2} ]] ; then 
-         print_info_msg "VERBOSE" "found HRRR-AK ${ind} hour forecast (from ${PRE_YYYYMMDD}_${PRE_HH}Z) grib2 file ${hrrr_guess_grb2} and retrieve Surface Visibility from it: "
+         info_msg="found HRRR-AK ${ind} hour forecast (from ${PRE_YYYYMMDD}_${PRE_HH}Z) grib2 file ${hrrr_guess_grb2} and retrieve Surface Visibility from it: "
+         echo "${info_msg}"
          rm -f ./hrrr_guess.grib2
          ln -sf ${hrrr_guess_grb2}   ./hrrr_guess.grib2
          if [ $ind == 0 ]; then

--- a/scripts/akrtma3d/exakrtma3d_updatevars.ksh
+++ b/scripts/akrtma3d/exakrtma3d_updatevars.ksh
@@ -23,8 +23,8 @@ export OMP_NUM_THREADS=1
 
 
 # Check to make sure required directory defined and existed
-check_if_defined "FCST_LENGTH" "DATA_GSIANL" "FIXwrf" "PDY" "cyc" 
-check_dirs_exist "DATA_GSIANL" "FIXwrf"
+check_if_defined "FCST_LENGTH" "DATA_SHARED" "FIXwrf" "PDY" "cyc" 
+check_dirs_exist "DATA_SHARED" "FIXwrf"
 
 # Initialize an array of WRF input dat files that need to be linked
 set -A WRF_DAT_FILES ${FIXwrf}/run/LANDUSE.TBL          \
@@ -99,22 +99,15 @@ cd ${DATAHOME}
 ${ECHO} "enter working directory:${DATAHOME}"
 
 export WRF_NAMELIST=${DATAHOME}/namelist.input
-# ${CP} ${PARMwrf}/hrrr_alaska.nl ${WRF_NAMELIST}
-if [[ ${L_WRFARW_NOFCST} =~ [TtYy] ]] ; then
-  echo "DO NOT USE IO-QUILTING in model run (with modified WRF model that does no actual foreast)"
-  ${CP} ${PARMwrf}/hrrr_alaska.noQuilt.nl ${WRF_NAMELIST} 
-else
-  echo "USE IO-QUILTING in model run (with original WRF model doing forecast)"
-  ${CP} ${PARMwrf}/hrrr_alaska.Quilt.nl   ${WRF_NAMELIST} 
-fi
+${CP} ${PARMwrf}/hrrr_alaska.nl ${WRF_NAMELIST}      # No IO-Quilting in wrf namelist as default
 
-
-if [ -r ${DATAHOME}/wrf_inout ]; then
-${ECHO} " Initial condition ${DATAHOME}/wrf_inout "
-${LN} -s ${DATAHOME}/wrf_inout wrfinput_d01
-#${LN} -s /gpfs/dell2/emc/modeling/noscrub/Edward.Colon/wrf_inout wrfinput_d01
+# Check to make sure the ICs file (wrfinput_d01) file exists
+if [ -r ${DATA_SHARED}/wrf_inout ]; then
+  ${ECHO} " Initial condition ==> ${DATA_SHARED}/wrf_inout "
+  ${CP} ${DATA_SHARED}/wrf_inout ${DATAHOME}/wrf_inout
+  ${LN} -s ${DATAHOME}/wrf_inout wrfinput_d01
 else
-  ${ECHO} "ERROR: ${DATAHOME}/wrf_inout does not exist, or is not readable"
+  ${ECHO} "ERROR: ${DATA_SHARED}/wrf_inout does not exist, or is not readable"
   exit 1
 fi
 
@@ -189,7 +182,6 @@ else
 fi
 
 
-
 # Run WRF to update reflectivity fields
 # export pgm="${NET}_wrfarw_fcst"
 if [[ ${L_WRFARW_NOFCST} =~ [TtYy] ]] ; then
@@ -234,12 +226,18 @@ ${ECHO} "Assemble Reflectivity fields back into wrf_inout"
 
 ${NCKS} -A -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM wrfout_d01 wrf_inout
 
-if [ -f ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
-  ${ECHO} "Erasing the GSI generated analysis file to be replaced by modified analysis."
-  ${MV} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUTgsi_rtma3d}/old_analysis
-fi
+## skipping the following if-block which saves the old analysis file 
+#   (since only reflectivity fields are updated, and the original reflectivity are available
+#     in the firstguess file which is saved.)
+# if [ -f ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
+#   ${ECHO} "Erasing the GSI generated analysis file to be replaced by modified analysis."
+#   ${MV} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUTgsi_rtma3d}/old_analysis
+# fi
 
-${CP_LN} -p wrf_inout ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+# coping the final updated analysis file wrf_inout to COM2, and saving it under shared directory as backup.
+${CP} -p wrf_inout ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+${MV} -p wrf_inout ${DATA_SHARED}/wrf_inout
+${LN} -sf ${DATA_SHARED}/wrf_inout     ./wrf_inout       # linking back as a back-up
 
 ${ECHO} "update_vars.ksh completed successfully at `${DATE}`"
 

--- a/scripts/exrtma3d_ncdiag.ksh
+++ b/scripts/exrtma3d_ncdiag.ksh
@@ -37,9 +37,9 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then
 
 fi
 
-# Directory where the original not-comnbined nc4 obs-diag files are saved
-#           (default ==> GSI RUNING/WORKING directory)
-  DATAGSI=${DATAGSIHOME:-"../gsiprd"}
+# Directory where the original split obs-diag files (netcdf4) are saved
+#           (default ==> the shared directory)
+  DATAGSI=${DATAGSI:-"${DATA_SHARED}"}
 
 # Compute date & time components for the analysis time
   subcyc=${subcyc:-"00"}

--- a/scripts/rtma3d/exrtma3d_anldump.ksh
+++ b/scripts/rtma3d/exrtma3d_anldump.ksh
@@ -24,11 +24,14 @@ check_dirs_exist() { #usage: check_dirs_exist "var1_name" "var2_name" ...
   check_if_defined "COMOUTgsi_rtma3d"
   check_dirs_exist "COMOUTgsi_rtma3d"
   check_if_defined "ANLrtma3d_FNAME"
+  check_if_defined "DATA_SHARED"
+  check_dirs_exist "DATA_SHARED"
 #  checking the directory where firstguess file (grib2) of howv/gust/vis is saved
   check_if_defined "COMOUT"
   check_dirs_exist "COMOUT"
 
-  ncf_anl=${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+# ncf_anl=${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+  ncf_anl=${DATA_SHARED}/wrf_inout
 
 #############################################################################
 # Make sure START_TIME is defined and in the correct format

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -840,13 +840,10 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
 #    follow-up updatevars step, this analysis file is only copied to the Shared directory (sharedprd).
 #    The final file wrf_inout would be copied to COM2 at the end of updatevars step after it is finalized.
 # ${CP} -p ${DATA}/wrf_inout                   ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
-# ${CP} -p ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # copying big file takes time
-  ${MV}    ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # using "mv" to save time
-  ${LN} -sf ${DATA_SHARED}/wrf_inout           ${DATA}/wrf_inout        # linking wrf_inout back to analysis directory (as a back-up)
-
-# copy the split obs-diag files (nc4) to shared directory (for the follow-up ncdiag step)
-# ${CP} -p {DATA}/pe*.nc4                      ${DATA_SHARED}           # copying takes time
-  ${MV}    {DATA}/pe*.nc4                      ${DATA_SHARED}           # moving  saves time
+  ${CP} -p ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # copying big file takes time
+#    if need to save the wall-clock time of this scipt, use the following two lines (moving instead of copying)
+# ${MV}    ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # using "mv" to save time
+# ${LN} -sf ${DATA_SHARED}/wrf_inout           ${DATA}/wrf_inout        # linking wrf_inout back to analysis directory (as a back-up)
 
   tar -cvf obsfit_fort220_${cycle_str}.tar     ./fort.* ./fit_* ./stdout* ./minimization_fort220.${cycle_str}
   ${CP} -p obsfit_fort220_${cycle_str}.tar     ${COMOUTgsi_rtma3d}
@@ -861,10 +858,37 @@ if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
   ${CP} -p hybens_info                         ${COMOUTgsi_rtma3d}
   ${CP} -p stdout                              ${COMOUTgsi_rtma3d}
   ${CP} -p OUTPUT*                             ${COMOUTgsi_rtma3d}
-#  extra backup (NOT necessary)
+#   extra backup (NOT necessary)
 # ${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
 # ${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
 # ${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
+
+#   Copy the split obs-diag files (nc4) to shared directory (for the follow-up ncdiag step)
+# ${MV}    {DATA}/pe*.nc4                      ${DATA_SHARED}           # moving  saves time
+# ${CP} -p {DATA}/pe*.nc4                      ${DATA_SHARED}           # copying thousand small files takes time (6~10 mins)
+#   using cfp command to copy files to save time
+  ncdiag_list=$(ls pe*.nc4)
+  n_files=$(echo ${ncdiag_list} | wc -w)
+  rm -f cp_cfp_cmdfile.txt
+  ic4=0
+  date
+  for f in ${ncdiag_list}
+  do
+    echo "cp -p ${DATA}/${f}  ${DATA_SHARED}/${f}" >> cp_cfp_cmdfile.txt
+    ic4=$((ic4+1))
+  done
+  echo $ic4  ${n_files}
+  echo "========  before copy pe*.nc4 ========================================================="
+  date
+  export exename=cfp
+  export CMDFILE=cp_cfp_cmdfile.txt
+  export nvar=60
+  command="mpiexec -np ${nvar} --cpu-bind verbose,core ${exename} $CMDFILE >> cp_cfp.stdout 2>&1"
+  echo $command
+  $command
+  date
+  echo "========  after  copy pe*.nc4 ========================================================="
+
 fi  
 #${RM} -f ${DATA}/sig*
 #${RM} -f ${DATA}/obs*

--- a/scripts/rtma3d/exrtma3d_gsianl.ksh
+++ b/scripts/rtma3d/exrtma3d_gsianl.ksh
@@ -254,6 +254,18 @@ elif [[ ${nummem} -eq 80 ]]; then
      HYBENS_INFO=${PARMgsi}/hybens_info
      ${CP} ${PARMgsi}/hybens_info hybens_info
   fi
+  # link GDAS ensemble members to the analysis working directory
+  # read gdas ensemble file names (with full path name) in filelist03
+  c=0
+  while read line_mem
+  do
+     let "c=c+1"
+     ccc=$(printf "%03d" $c)
+     en_linkname="ens_mem${ccc}"
+     [[ -f ./${en_linkname} ]] && rm -f ./${en_linkname}
+     echo "linking ${en_linkname}: --> ${line_mem}"
+     ${LN} -sf ${line_mem} ./${en_linkname}
+  done < ./filelist03
   ${ECHO} " Cycle ${YYYYMMDDHH}: GSI hybrid uses GDAS directly with n_ens=${nummem}" >> ${pgmout}
 else
   beta1_inv=1.0
@@ -823,22 +835,36 @@ fi ###### second GSI run
                                                               # (saving space, but costing more time)
 
 if [ "${envir}" == "lsf" ] || [ "${envir}" == "pbspro" ]; then #wcoss
-  ${CP} -p ${DATA}/wrf_inout                   ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
-  ${CP} -p minimization_fort220.${cycle_str}   ${COMOUTgsi_rtma3d}
-  tar -cvf obsfit_fort220_${cycle_str}.tar     ./fort.* ./fit_* ./stdout*
-  ${CP} -p  obsfit_fort220_${cycle_str}.tar    ${COMOUTgsi_rtma3d}
+
+#  Some variables (reflectivity, etc.) in analysis file (wrf_inout) would be updated in the
+#    follow-up updatevars step, this analysis file is only copied to the Shared directory (sharedprd).
+#    The final file wrf_inout would be copied to COM2 at the end of updatevars step after it is finalized.
+# ${CP} -p ${DATA}/wrf_inout                   ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+# ${CP} -p ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # copying big file takes time
+  ${MV}    ${DATA}/wrf_inout                   ${DATA_SHARED}/wrf_inout # using "mv" to save time
+  ${LN} -sf ${DATA_SHARED}/wrf_inout           ${DATA}/wrf_inout        # linking wrf_inout back to analysis directory (as a back-up)
+
+# copy the split obs-diag files (nc4) to shared directory (for the follow-up ncdiag step)
+# ${CP} -p {DATA}/pe*.nc4                      ${DATA_SHARED}           # copying takes time
+  ${MV}    {DATA}/pe*.nc4                      ${DATA_SHARED}           # moving  saves time
+
+  tar -cvf obsfit_fort220_${cycle_str}.tar     ./fort.* ./fit_* ./stdout* ./minimization_fort220.${cycle_str}
+  ${CP} -p obsfit_fort220_${cycle_str}.tar     ${COMOUTgsi_rtma3d}
   tar -cvf misc_info_${cycle_str}.tar  ./*info ./errtable ./prepobs_prep.bufrtable  ./*bias*  \
-    ./current_bad_aircraft ./gsd_sfcobs_uselist.txt ./gsd_sfcobs_provider.txt ./stdout*
-  ${CP} -p  misc_info_${cycle_str}.tar         ${COMOUTgsi_rtma3d}
+    ./current_bad_aircraft ./*sfcobs_uselist* ./gsd_sfcobs_provider.txt ./stdout* ./filelist* \
+    ./OUTPUT*
+  ${CP} -p misc_info_${cycle_str}.tar          ${COMOUTgsi_rtma3d}
+
+  ${CP} -p minimization_fort220.${cycle_str}   ${COMOUTgsi_rtma3d}
   ${CP} -p filelist.hrrrdas 		       ${COMOUTgsi_rtma3d}
   ${CP} -p filelist03                          ${COMOUTgsi_rtma3d}
   ${CP} -p hybens_info                         ${COMOUTgsi_rtma3d}
   ${CP} -p stdout                              ${COMOUTgsi_rtma3d}
   ${CP} -p OUTPUT*                             ${COMOUTgsi_rtma3d}
-  # extra backup (NOT necessary)
-  #${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
-  #${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
-  #${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
+#  extra backup (NOT necessary)
+# ${LN} -sf ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUT}/${ANLrtma3d_FNAME}
+# ${CP} -p ${pgmout_stdout}        ${COMOUT}/${pgmout_stdout}_gsianl.${cycle_str}
+# ${CP} -p fits_${cycle_str}.txt  ${COMOUT}/fits_${cycle_str}.txt
 fi  
 #${RM} -f ${DATA}/sig*
 #${RM} -f ${DATA}/obs*

--- a/scripts/rtma3d/exrtma3d_prepfgs.ksh
+++ b/scripts/rtma3d/exrtma3d_prepfgs.ksh
@@ -92,7 +92,12 @@ CDATE=$PDY$cyc
 
    found_hrrrges=no
    ic=1
-   while [ $ic -le 9 ] ; do
+   ic_max=9                                 # max hours to search back for hrrr forecast file
+   targetsize_hrrr=16057259932              # HRRRv4 on WCOSS2 (forecast/restart history file)
+   ics_max=15                               # max times to check the filesize of hrrr forecast
+   sleep_time=60
+#  loop of searching for firstguess in HRRR forecast file
+   while [ $ic -le ${ic_max} ] ; do
      hrrrFHH=$ic
      hrrrFHH=`printf %02d $hrrrFHH`
      hrrrCYCLE=`$NDATE -$hrrrFHH $CDATE`
@@ -102,19 +107,49 @@ CDATE=$PDY$cyc
 #    probe_hrrr_guess_nc=$GESINhrrr/conus/hrrr_${hrrrCYCLE}f0${hrrrFHH}
 #    probe_hrrr_guess_nc=$GESINhrrr/hrrr_${hrrrCYCLE}f0${hrrrFHH}
      export probe_hrrr_guess_nc=hrrr_${hrrrCYCLE}f0${hrrrFHH}
+     size_match=no
+     found_hrrrges=no
      if [ -s $GESINhrrr/$probe_hrrr_guess_nc ]; then
          found_hrrrges=yes
-#        cpreq ${probe_hrrr_guess_nc} $COMOUT/${RUN}.t${cyc}z.hrrr_${hrrrCYCLE}f0${hrrrFHH}
-         cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/
-         cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}
-        break
-     else
-        let "ic=ic+1"
-      fi
-   done
-   echo "found_hrrrges: "$found_hrrrges
 
-   if [[ ${found_hrrrges} = no ]] ; then
+         ics=1
+#        loop of checking the filesize of hrrr forecast
+         while [ $ics -le ${ics_max} ] ; do
+             filesize=$(stat -c %s $GESINhrrr/$probe_hrrr_guess_nc)
+             if [[ ${filesize} -eq ${targetsize_hrrr} ]] ; then
+                 size_match="yes"
+#                cpreq ${probe_hrrr_guess_nc} $COMOUT/${RUN}.t${cyc}z.hrrr_${hrrrCYCLE}f0${hrrrFHH}
+#                cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}
+                 break  # breaking out the loop of checking file size
+             else
+                 size_match="no"
+                 msg="${probe_hrrr_guess_nc} filesize (${filesize}) does not match the standard size (${targetsize_hrrr}). Sleep for 60 seconds and check again ..."
+                 ${ECHO} "${msg}"
+                 sleep ${sleep_time}
+             fi
+             let "ics=ics+1"
+         done
+
+         if [[ ${size_match} =~ [yYtT] ]] ; then
+             cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}
+             break      # breaking out the loop of searching for firstguess in HRRR forecast
+         else
+             msg="hrrr ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Trying to search in the earlier hrrr forecast files ..."
+             ${ECHO} "${msg}"
+             cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${probe_hrrr_guess_nc}."wrongfsize"  # save this problematic file for investigation later 
+#            cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}                   # do not copy the problematic file as fgs for analysis
+         fi
+     else
+         msg="HRRR ${ic}-hour forecat file ${probe_hrrr_guess_nc} is not available. Try with earlier HRRR foreast file ... "
+         ${ECHO} "${msg}"
+     fi
+
+     let "ic=ic+1"
+
+   done
+   echo "found_hrrrges: "$found_hrrrges  "  size_match: ${size_match}"
+
+   if [[ ${found_hrrrges} =~ [NnFf] ]] ; then
        err_exit "No HRRR guess available. The missing files in the above while-do loop are of the form GESINhrrr/conus/hrrr_${hrrrCYCLE}f0${hrrrFHH}. The script must be able to find at least one file out of the 9 files that it queries"
    fi
 

--- a/scripts/rtma3d/exrtma3d_prepfgs.ksh
+++ b/scripts/rtma3d/exrtma3d_prepfgs.ksh
@@ -115,7 +115,12 @@ CDATE=$PDY$cyc
          ics=1
 #        loop of checking the filesize of hrrr forecast
          while [ $ics -le ${ics_max} ] ; do
-             filesize=$(stat -c %s $GESINhrrr/$probe_hrrr_guess_nc)
+             if [ -L "$GESINhrrr/$probe_hrrr_guess_nc" ] ; then
+                 realfgsfile=$(readlink -f $GESINhrrr/$probe_hrrr_guess_nc)
+             else
+                 realfgsfile="$GESINhrrr/$probe_hrrr_guess_nc"
+             fi
+             filesize=$(stat -c %s ${realfgsfile})
              if [[ ${filesize} -eq ${targetsize_hrrr} ]] ; then
                  size_match="yes"
 #                cpreq ${probe_hrrr_guess_nc} $COMOUT/${RUN}.t${cyc}z.hrrr_${hrrrCYCLE}f0${hrrrFHH}
@@ -131,16 +136,30 @@ CDATE=$PDY$cyc
 
          if [[ ${size_match} =~ [yYtT] ]] ; then
              cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}
+             msg="HRRR ${ic}-hour forecast file ${probe_hrrr_guess_nc} is used as the firstguess for analysis cycle at ${PDY} ${cyc}Z"
+             ${ECHO} "${msg}"
+             postmsg "$jlogfile" "$msg"
              break      # breaking out the loop of searching for firstguess in HRRR forecast
          else
-             msg="hrrr ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Trying to search in the earlier hrrr forecast files ..."
-             ${ECHO} "${msg}"
 #            cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later 
              cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${GESINhrrr_rtma3d}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later 
+             msg="HRRR ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists for analysis cycle at ${PDY} ${cyc}Z, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Try to search in the earlier HRRR forecast files ..."
+             ${ECHO} "${msg}"
+             postmsg "$jlogfile" "$msg"
+             SUBJECT=" ${NET} ${RUN} Warning Email: File Size of Firstguess Does Not Match for analysis cycle at ${PDY} ${cyc}Z"
+             MESSAGE="WARNING: ${msg}"
+             ${ECHO} "${MESSAGE}" | ${MAILX} -s "$SUBJECT" -c "${CC_RECIPIENTS}"  "${TO_RECIPIENTS}"
+#            ${ECHO} "${MESSAGE}" | mail.py   #<-- using this line only when system is delivered to NCO
+
          fi
      else
-         msg="HRRR ${ic}-hour forecat file ${probe_hrrr_guess_nc} is not available. Try with earlier HRRR foreast file ... "
+         msg="HRRR ${ic}-hour forecat file ${probe_hrrr_guess_nc} is not available for analysis cycle at ${PDY} ${cyc}Z. Try to search in the earlier HRRR foreast files ... "
          ${ECHO} "${msg}"
+         postmsg "$jlogfile" "$msg"
+         SUBJECT=" ${NET} ${RUN} Warning Email: Missing Firstguess File for analysis cycle at ${PDY} ${cyc}Z"
+         MESSAGE="WARNING: ${msg}"
+         ${ECHO} "${MESSAGE}" | ${MAILX} -s "$SUBJECT" -c "${CC_RECIPIENTS}"  "${TO_RECIPIENTS}"
+#        ${ECHO} "${MESSAGE}" | mail.py   #<-- using this line only when system is delivered to NCO
      fi
 
      let "ic=ic+1"
@@ -182,7 +201,9 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
   grid_specs=${grid_specs_hrrr}
 #
 # 1.2  fix dir (for slmask.grib2 file)
-  print_info_msg "$VERBOSE" "FIXgsi is $FIXgsi"
+# print_info_msg "$VERBOSE" "FIXgsi is $FIXgsi"   (print_info_msg is only available in RRFS worklfow)
+  info_msg="FIXgsi is $FIXgsi"
+  echo "$info_msg"
 #
 #  Sea-Land Mask for the correct interpolation of the howv Background.
   rm -f ./slmask.grib2
@@ -197,7 +218,8 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
 #    then dumping out to grib2 file
 # 2.1 Wave Background at Great Lakes
 #
-  print_info_msg "$VERBOSE" "COMINww3GL is $COMINww3GL (Wave background from Great Lakes model)"
+  info_msg="COMINww3GL is $COMINww3GL (Wave background from Great Lakes model)"
+  echo "$info_msg"
 
    found_ww3gesGL=no
    ic=0
@@ -212,7 +234,8 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
 #
       if [ -s $probe_ww3_GL_guess_grb2 ]; then
 
-         print_info_msg "$VERBOSE" "found wave background for Great Lakes: $probe_ww3_GL_guess_grb2"
+         info_msg="found wave background for Great Lakes: $probe_ww3_GL_guess_grb2"
+         echo "${info_msg}"
          cpreq $probe_ww3_GL_guess_grb2 ww3.guess5.grib2
 #        cp -p $probe_ww3_GL_guess_grb2 ww3.guess5.grib2
          cp -p $probe_ww3_GL_guess_grb2 $COMOUT/glwu.grlr_500m.t${ww3CC_GL}z.grib2     # save for retro run
@@ -240,7 +263,8 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
    fi
 #
 # 2.2 Ocean Waves Background
-  print_info_msg "$VERBOSE" "COMINww3 is $COMINww3 (Wave background from WW3 Ocean Wave model)"
+  info_msg="COMINww3 is $COMINww3 (Wave background from WW3 Ocean Wave model)"
+  echo "${info_msg}"
    found_ww3ges=no
    ic=0
    while [ $ic -le 24 ] ; do
@@ -265,8 +289,10 @@ if [[ ${RUN_HOWV} =~ [TtYy] ]] ; then
       if [ -s "${probe_ww3_guess_grb2[0]}" ] && \
          [ -s "${probe_ww3_guess_grb2[1]}" ]    ; then
 
-         print_info_msg "$VERBOSE" "found wave background for Arctic: ${probe_ww3_guess_grb2[0]}"
-         print_info_msg "$VERBOSE" "found wave background for Global: ${probe_ww3_guess_grb2[1]}"
+         info_msg="found wave background for Arctic: ${probe_ww3_guess_grb2[0]}"
+         echo "${info_msg}"
+         info_msg="found wave background for Global: ${probe_ww3_guess_grb2[1]}"
+         echo "${info_msg}"
          cpreq ${probe_ww3_guess_grb2[0]} ww3.guess0.grib2
 #        cp -p ${probe_ww3_guess_grb2[0]} ww3.guess0.grib2
          cpreq ${probe_ww3_guess_grb2[1]} ww3.guess1.grib2
@@ -410,7 +436,8 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
       hrrr_guess_grb2=${COMINHRRR}/hrrr.${PRE_YYYYMMDD}/conus/hrrr.t${PRE_HH}z.wrfprsf${ic2}.grib2    # wrfprs; wrfnat; wrfsfc;
 
       if [[ -f ${hrrr_guess_grb2} ]] ; then 
-         print_info_msg "VERBOSE" "found HRRR ${ic} hour forecast grib2 file ${hrrr_guess_grb2} and retrieve 10-m Wind Gust from it: "
+         info_msg="found HRRR ${ic} hour forecast grib2 file ${hrrr_guess_grb2} and retrieve 10-m Wind Gust from it: "
+         echo "${info_msg}"
          rm -f ./hrrr_guess.grib2
          ln -sf ${hrrr_guess_grb2}   ./hrrr_guess.grib2
          if [ $ic == 0 ]; then
@@ -547,7 +574,8 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
       hrrr_guess_grb2=${COMINHRRR}/hrrr.${PRE_YYYYMMDD}/conus/hrrr.t${PRE_HH}z.wrfprsf${ic2}.grib2    # wrfprs; wrfnat; wrfsfc;
 
       if [[ -f ${hrrr_guess_grb2} ]] ; then 
-         print_info_msg "VERBOSE" "found HRRR ${ic} hour forecast grib2 file ${hrrr_guess_grb2} and retrieve Surface Visibility from it: "
+         info_msg="found HRRR ${ic} hour forecast grib2 file ${hrrr_guess_grb2} and retrieve Surface Visibility from it: "
+         echo "${info_msg}"
          rm -f ./hrrr_guess.grib2
          ln -sf ${hrrr_guess_grb2}   ./hrrr_guess.grib2
          if [ $ic == 0 ]; then

--- a/scripts/rtma3d/exrtma3d_prepfgs.ksh
+++ b/scripts/rtma3d/exrtma3d_prepfgs.ksh
@@ -92,9 +92,9 @@ CDATE=$PDY$cyc
 
    found_hrrrges=no
    ic=1
-   ic_max=9                                 # max hours to search back for hrrr forecast file
-   targetsize_hrrr=16057259932              # HRRRv4 on WCOSS2 (forecast/restart history file)
-   ics_max=15                               # max times to check the filesize of hrrr forecast
+   ic_max=9                         # max hours to search back for hrrr forecast file
+   targetsize_hrrr=16057259932      # HRRRv4 on CONUS on WCOSS2 (forecast/restart history file)
+   ics_max=15                       # max times to check the filesize of hrrr forecast
    sleep_time=60
 #  loop of searching for firstguess in HRRR forecast file
    while [ $ic -le ${ic_max} ] ; do
@@ -119,7 +119,6 @@ CDATE=$PDY$cyc
              if [[ ${filesize} -eq ${targetsize_hrrr} ]] ; then
                  size_match="yes"
 #                cpreq ${probe_hrrr_guess_nc} $COMOUT/${RUN}.t${cyc}z.hrrr_${hrrrCYCLE}f0${hrrrFHH}
-#                cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}
                  break  # breaking out the loop of checking file size
              else
                  size_match="no"
@@ -136,8 +135,8 @@ CDATE=$PDY$cyc
          else
              msg="hrrr ${ic}-hour forecast file ${probe_hrrr_guess_nc} exists, but its filesize (${filesize}) does not match the standard size (${targetsize_hrrr}) even after waiting for ${ics_max} minutes. Trying to search in the earlier hrrr forecast files ..."
              ${ECHO} "${msg}"
-             cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${probe_hrrr_guess_nc}."wrongfsize"  # save this problematic file for investigation later 
-#            cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${FGSrtma3d_FNAME}                   # do not copy the problematic file as fgs for analysis
+#            cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${DATA}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later 
+             cpreq $GESINhrrr/${probe_hrrr_guess_nc} ${GESINhrrr_rtma3d}/${probe_hrrr_guess_nc}.wrongfsize  # saving this problematic file for investigation later 
          fi
      else
          msg="HRRR ${ic}-hour forecat file ${probe_hrrr_guess_nc} is not available. Try with earlier HRRR foreast file ... "
@@ -673,7 +672,7 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
     if [ -r ${DATA}/${FGSrtma3d_FNAME} ] ; then
 #      ${LN} -sf ${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME}     ${DATA}/${FGSrtma3d_FNAME}
        ${ECHO} "PREPFGS: Saving the Firstguess of Cycle ${YYYYMMDDHH} --> ${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME} "
-       cp -p ${DATA}/${probe_hrrr_guess_nc} ${GESINhrrr_rtma3d}/
+#      cp -p ${DATA}/${probe_hrrr_guess_nc} ${GESINhrrr_rtma3d}/     # ${DATA}/${probe_hrrr_guess_nc} does not exist
        cp -p ${DATA}/${FGSrtma3d_FNAME}     ${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME}    
 
 #      to save the disck space, removing the firstguess file under working directry (fgsprd), 
@@ -690,5 +689,7 @@ fi     # RUN_HOWV=True/true/Yes/yes, then retrieving fgs of howv
 export err=$? ; err_chk
 
 ls -l ${GESINhrrr_rtma3d} > ${GESINhrrr_rtma3d}/fgs_data_${PDY}_${cyc}.list
+${ECHO} "===========================" >> ${GESINhrrr_rtma3d}/fgs_data_${PDY}_${cyc}.list
+${ECHO} "${GESINhrrr_rtma3d}/${FGSrtma3d_FNAME} comes originally from ${GESINhrrr}/${probe_hrrr_guess_nc}" >> ${GESINhrrr_rtma3d}/fgs_data_${PDY}_${cyc}.list
 
 exit 0

--- a/scripts/rtma3d/exrtma3d_updatevars.ksh
+++ b/scripts/rtma3d/exrtma3d_updatevars.ksh
@@ -18,14 +18,13 @@ check_dirs_exist() { #usage: check_dirs_exist "var1_name" "var2_name" ...
   done
 }
 
-
 export OMP_NUM_THREADS=1
 
 
 
 # Check to make sure required directory defined and existed
-check_if_defined "FCST_LENGTH" "DATA_GSIANL" "FIXwrf" "PDY" "cyc" 
-check_dirs_exist "DATA_GSIANL" "FIXwrf"
+check_if_defined "FCST_LENGTH" "DATA_SHARED" "FIXwrf" "PDY" "cyc" 
+check_dirs_exist "DATA_SHARED" "FIXwrf"
 
 # Initialize an array of WRF input dat files that need to be linked
 set -A WRF_DAT_FILES ${FIXwrf}/run/LANDUSE.TBL          \
@@ -90,7 +89,7 @@ time_str2=`${DATE} "+%Y-%m-%d_%H_00_00" -d "${START_TIME}"`
 END_TIME=`${DATE} -d "${START_TIME}  ${FCST_LENGTH} seconds"`
 
 # Choose to use the modified model that does not do the integral (default: to avoid model crash)
-#     or to use the original model (export L_WRFARW_NOFCST = "False", or "No")
+#     or to use the original model (export L_WRFARW_NOFCST = "False" or "No")
 export L_WRFARW_NOFCST=${L_WRFARW_NOFCST:-"True"}   # default: using the modified model to 
                                                     #   avoid possible model crash, and must
                                                     #   turn off IO-quilting in namelist.
@@ -100,16 +99,9 @@ cd ${DATAHOME}
 ${ECHO} "enter working directory:${DATAHOME}"
 
 export WRF_NAMELIST=${DATAHOME}/namelist.input
-# ${CP} ${PARMwrf}/hrrr_conus.nl ${WRF_NAMELIST}
-if [[ ${L_WRFARW_NOFCST} =~ [TtYy] ]] ; then
-  echo "DO NOT USE IO-QUILTING in model run (with modified WRF model that does no actual foreast)"
-  ${CP} ${PARMwrf}/hrrr_conus.noQuilt.nl ${WRF_NAMELIST} 
-else
-  echo "USE IO-QUILTING in model run (with original WRF model doing forecast)"
-  ${CP} ${PARMwrf}/hrrr_conus.Quilt.nl   ${WRF_NAMELIST} 
-fi
+${CP} ${PARMwrf}/hrrr_conus.nl ${WRF_NAMELIST}      # No IO-Quilting in wrf namelist as default
 
-# Check to make sure the wrfinput_d01 file exists
+# Check to make sure the ICs file (wrfinput_d01) file exists
 #if [ -r ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
 #  ${ECHO} " Initial condition ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} "
 #  ${LN} -s ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} wrfinput_d01
@@ -118,13 +110,12 @@ fi
 #  ${ECHO} "ERROR: ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} does not exist, or is not readable"
 #  exit 1
 #fi
-
-if [ -r ${DATAHOME}/wrf_inout ]; then
-${ECHO} " Initial condition ${DATAHOME}/wrf_inout "
-${LN} -s ${DATAHOME}/wrf_inout wrfinput_d01
-#${LN} -s /gpfs/dell2/emc/modeling/noscrub/Edward.Colon/wrf_inout wrfinput_d01
+if [ -r ${DATA_SHARED}/wrf_inout ]; then
+  ${ECHO} " Initial condition ==> ${DATA_SHARED}/wrf_inout "
+  ${CP} ${DATA_SHARED}/wrf_inout ${DATAHOME}/wrf_inout
+  ${LN} -s ${DATAHOME}/wrf_inout wrfinput_d01
 else
-  ${ECHO} "ERROR: ${DATAHOME}/wrf_inout does not exist, or is not readable"
+  ${ECHO} "ERROR: ${DATA_SHARED}/wrf_inout does not exist, or is not readable"
   exit 1
 fi
 
@@ -243,7 +234,7 @@ ${ECHO} "Assemble Reflectivity fields back into wrf_inout"
 
 ${NCKS} -A -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM wrfout_d01 wrf_inout
 
-## skipping the following if-block which savs the old analysis file 
+## skipping the following if-block which saves the old analysis file 
 #   (since only reflectivity fields are updated, and the original reflectivity are available
 #     in the firstguess file which is saved.)
 # if [ -f ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ]; then
@@ -251,7 +242,10 @@ ${NCKS} -A -v REFL_10CM,COMPOSITE_REFL_10CM,REFL_10CM_1KM,REFL_10CM_4KM wrfout_d
 #   ${MV} ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME} ${COMOUTgsi_rtma3d}/old_analysis
 # fi
 
-${CP_LN} -p wrf_inout ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+# coping the final updated analysis file wrf_inout to COM2, and saving it under shared directory as backup.
+${CP} -p wrf_inout ${COMOUTgsi_rtma3d}/${ANLrtma3d_FNAME}
+${MV} -p wrf_inout ${DATA_SHARED}/wrf_inout
+${LN} -sf ${DATA_SHARED}/wrf_inout     ./wrf_inout       # linking back as a back-up
 
 ${ECHO} "update_vars.ksh completed successfully at `${DATE}`"
 

--- a/sorc/build_rtma3d_wrfarw.sh
+++ b/sorc/build_rtma3d_wrfarw.sh
@@ -19,6 +19,7 @@ module list
 sleep 1
 
 cd ${BASE}/rtma3d_wrfarw.fd/WRFV3.9
+mkdir ./run                      # avoiding the error message at the end of building wrfarw
 ./clean -aa
 ./clean -a
 ./clean

--- a/util_dev/getbest_EnKF_FV3GDAS.py
+++ b/util_dev/getbest_EnKF_FV3GDAS.py
@@ -108,9 +108,10 @@ def write_filelist(fname,comenkf,fsave,svdate,retro,path,suf,o3fname,getmean,gfs
             en=path+'/sfg_'+svcdate+'_fhr'+str(fsave).zfill(2)+'s_mem'+mem+suf
         if is_non_zero_file(en):
             f.write(en+'\n')
-            # Also sym link the file to working directory'
-            linkname='ens_mem'+mem
-            force_symlink(en,linkname)
+            # Also sym link the file to working directory
+            # (No linking to GDAS ensemble here! It is done in analysis script.)
+            # linkname='ens_mem'+mem
+            # force_symlink(en,linkname)
         else:
             havefile=False
             n=n-1   # Remove the erroneously added member

--- a/workflow/launch.ksh
+++ b/workflow/launch.ksh
@@ -194,6 +194,12 @@ export GREP=/usr/bin/grep
 export UNZIP=/bin/unzip
 export TOUCH=/usr/bin/touch
 
+# for mail
+  export MAILX=/usr/bin/mailx       # env variable MAIL is used by linux system
+  export TO_RECIPIENTS="${USER}@noaa.gov"
+  export CC_RECIPIENTS="annette.gibbs@noaa.gov,matthew.t.morris@noaa.gov,manuel.pondeca@noaa.gov,gang.zhao@noaa.gov"
+# export BCC_RECIPIENTS=""
+
 else
   echo "modulefile has not set up for this unknow machine. Job abort!"
   exit 1

--- a/workflow/rtma3d_pbspro_alaska.xml
+++ b/workflow/rtma3d_pbspro_alaska.xml
@@ -49,7 +49,7 @@
 <!ENTITY HOMErtma3d	"&NWROOT;">
 <!ENTITY LOG_DIR	"/lfs/h2/emc/ptmp/&USER;/rtma3d_logs/alaska">
 <!ENTITY JJOB_DIR	"&HOMErtma3d;/jobs">
-<!ENTITY WORKFLOW_DIR   "&HOMErtma3d;/workflow">
+<!ENTITY WORKFLOW_DIR	"&HOMErtma3d;/workflow">
 <!ENTITY SCRIPT_DIR	"&HOMErtma3d;/scripts">
 <!ENTITY USHrtma3d	"&HOMErtma3d;/ush">
 <!ENTITY UTILrtma3d	"&HOMErtma3d;/util">
@@ -220,7 +220,7 @@
 <!ENTITY PREPOBS_RESERVATION '<nodes>1:ppn=1:vntype=cray_compute:mem=4000MB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
 <!ENTITY PREPFGS_PROC "1">
-<!ENTITY PREPFGS_RESOURCES '<walltime>00:15:00</walltime>'>
+<!ENTITY PREPFGS_RESOURCES '<walltime>00:30:00</walltime>'>
 <!ENTITY PREPFGS_RESERVATION '<nodes>1:ppn=1:vntype=cray_compute:mem=20GB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
 <!ENTITY GSI_PROC "14">
@@ -1323,6 +1323,10 @@
     &ENVARS;
     &UPDATEVARS_RESOURCES;
     &UPDATEVARS_RESERVATION;
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
+    </envar>
 
     <command>&WORKFLOW_DIR;/launch.ksh &JJOB_UPDATEVARS;</command>
     <jobname><cyclestr>&RUN;_updatevars_job_@Y@m@d@H@M</cyclestr></jobname>

--- a/workflow/rtma3d_pbspro_alaska.xml
+++ b/workflow/rtma3d_pbspro_alaska.xml
@@ -109,6 +109,8 @@
 <!ENTITY DATA_POSTSND   "&DATA_RUNDIR;/wrfbufr">
 <!ENTITY DATA_RHIST     "&DATA_RUNDIR;/rhist">
 <!ENTITY DATA_NCDIAG    "&DATA_RUNDIR;/ncdiagprd">
+<!ENTITY DATA_SHARED    "&DATA_RUNDIR;/sharedprd">
+<!ENTITY DATA_WRFPRD    "&DATA_RUNDIR;/wrfprd">
 
 <!ENTITY hpsspath0      "/NCEPDEV/emc-meso/5year/&USER;/pbspro_rtma3d">
 <!ENTITY hpsspath1      "/NCEPPROD/hpssprod/runhistory">
@@ -128,9 +130,7 @@
 <!ENTITY HOMEBASE_DIR	"&NWROOT;">
 <!ENTITY DATABASE_DIR	"&ptmp_base;">
 
-
 <!-- for workflow -->
-
 <!ENTITY maxtries	"3">
 <!ENTITY KEEPDATA	"YES">
 <!ENTITY SENDCOM	"YES">
@@ -599,6 +599,14 @@
    <envar>
       <name>DATA_ANLDUMP</name>
       <value><cyclestr>&DATA_ANLDUMP;</cyclestr></value>
+   </envar>
+   <envar>
+      <name>DATA_SHARED</name>
+      <value><cyclestr>&DATA_SHARED;</cyclestr></value>
+   </envar>
+   <envar>
+      <name>DATA_WRFPRD</name>
+      <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
    </envar>
 
    <envar>

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -111,6 +111,8 @@
 <!ENTITY DATA_RHIST     "&DATA_RUNDIR;/rhist">
 <!ENTITY DATA_HRRRDAS   "&DATA_RUNDIR;/hrrrdas">
 <!ENTITY DATA_NCDIAG    "&DATA_RUNDIR;/ncdiagprd">
+<!ENTITY DATA_SHARED    "&DATA_RUNDIR;/sharedprd">
+<!ENTITY DATA_WRFPRD    "&DATA_RUNDIR;/wrfprd">
 
 <!ENTITY hpsspath0      "/NCEPDEV/emc-meso/5year/&USER;/pbspro_rtma3d">
 <!ENTITY hpsspath1      "/NCEPPROD/hpssprod/runhistory">
@@ -621,6 +623,14 @@
    <envar>
       <name>DATA_ANLDUMP</name>
       <value><cyclestr>&DATA_ANLDUMP;</cyclestr></value>
+   </envar>
+   <envar>
+      <name>DATA_SHARED</name>
+      <value><cyclestr>&DATA_SHARED;</cyclestr></value>
+   </envar>
+   <envar>
+      <name>DATA_WRFPRD</name>
+      <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
    </envar>
 
    <envar>

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -224,7 +224,7 @@
 <!ENTITY PREPOBS_RESERVATION '<nodes>1:ppn=1:vntype=cray_compute:mem=4000MB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
 <!ENTITY PREPFGS_PROC "1">
-<!ENTITY PREPFGS_RESOURCES '<walltime>00:15:00</walltime>'>
+<!ENTITY PREPFGS_RESOURCES '<walltime>00:30:00</walltime>'>
 <!ENTITY PREPFGS_RESERVATION '<nodes>1:ppn=1:vntype=cray_compute:mem=50GB</nodes><native>-l place=scatter</native><queue>&QUEUE;</queue><account>&ACCOUNT;</account>'>
 
 <!ENTITY GSI_PROC "14">
@@ -1374,6 +1374,10 @@
     &ENVARS;
     &UPDATEVARS_RESOURCES;
     &UPDATEVARS_RESERVATION;
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
+    </envar>
 
     <command>&WORKFLOW_DIR;/launch.ksh &JJOB_UPDATEVARS;</command>
     <jobname><cyclestr>&RUN;_updatevars_job_@Y@m@d@H@M</cyclestr></jobname>


### PR DESCRIPTION
### Some updates to hrrr_3drtma:
   
1. In prepfgs script, when searching for the firstguess file in HRRR forecast files,  check the file size to make sure the firstguess file is good (simple data integrity check);
2. Making the updatevars step running under its own working directory (wrfprd), instead of under gsiprd;
3. Set up a share sub-directory under each cycle running top directory, and move or copy the data which need to be shared to other steps.  For example, wrf_inout, pe*.nc4 files generated by gsianl step, the wrf_inout would be used in updatevars and anldump steps, and the split diag files pe*nc4 would be used by ncdiag to combine them.
4. In util_dev/getbest_EnKF_FV3GDAS.py, it links the gdas ensemble to local running directoy. This linking action is not necessary if gdas ensemble would not be used in analysis. So the linking lines are commented off in util_dev/getbest_EnKF_FV3GDAS.py. 
5. Correspondingly, in gsianl script, if the gdas ensemble is used in hybrid analysis, then the gdas ensemble members are links to local analysis working directory.
6. In gsianl step, at the end of script, Using cfp command to parallelly copy the thousand of split netcdf-format obs-diag files to shared sub-directory. It might take 6-10 mins if copying these files serially.
7. A few minor issues:, such as in wrfare building script, adding a line to create a sub-directory "run/" in order to avoid the annoying warning message at the end of building.