### PR TITLE
Updated task dependency for wrfbufr task (run after updatevars)

### DIFF
--- a/workflow/rtma3d_pbspro_alaska.xml
+++ b/workflow/rtma3d_pbspro_alaska.xml
@@ -1212,6 +1212,28 @@
      </dependency>
   </task>
 
+  <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
+
+    &ENVARS;
+    &UPDATEVARS_RESOURCES;
+    &UPDATEVARS_RESERVATION;
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
+    </envar>
+
+    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_UPDATEVARS;</command>
+    <jobname><cyclestr>&RUN;_updatevars_job_@Y@m@d@H@M</cyclestr></jobname>
+    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_updatevars_@Y@m@d@H.log</cyclestr></join>
+
+    &ENVARS_UPDATEVARS;
+
+    <dependency>
+          <taskdep task="&RUN;_gsianl_task"/>
+    </dependency>
+
+  </task>
+
   <task name="&RUN;_ncdiag_task" cycledefs="hourly" maxtries="&maxtries;">
        
     &ENVARS;
@@ -1253,6 +1275,29 @@
     </dependency>
   </task>
 
+  <task name="&RUN;_autoqc_task" cycledefs="hourly" maxtries="&maxtries;">
+
+    &ENVARS;
+    &AUTOQC_RESOURCES;
+    &AUTOQC_RESERVATION;
+
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_AUTOQC;</cyclestr></value>
+    </envar>
+
+    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_AUTOQC;</command>
+    <jobname><cyclestr>&RUN;_autoqc_job_@Y@m@d@H@M</cyclestr></jobname>
+    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_autoqc_@Y@m@d@H.log</cyclestr></join>
+
+    &ENVARS_AUTOQC;
+
+    <dependency>
+          <taskdep task="&RUN;_gsianl_task"/>
+    </dependency>
+
+  </task>
+
   <task name="&RUN;_wrfbufr" cycledefs="hourly" maxtries="&maxtries;">
     &ENVARS;
     <envar>
@@ -1267,32 +1312,9 @@
     <jobname>&NET;_wrfbufr</jobname>
     <join><cyclestr>&LOG_DIR;/&RUN;_wrfbufr_@Y@m@d@H@M.log</cyclestr></join>
     <dependency>
-      <taskdep task="&RUN;_gsianl_task"/>
+      <taskdep task="&RUN;_updatevars_task"/>
     </dependency>
 
-  </task>
-
-  <task name="&RUN;_autoqc_task" cycledefs="hourly" maxtries="&maxtries;">
-   
-    &ENVARS;
-    &AUTOQC_RESOURCES;  
-    &AUTOQC_RESERVATION;
-      
-    <envar>
-       <name>rundir_task</name>
-       <value><cyclestr>&DATA_AUTOQC;</cyclestr></value>
-    </envar>
-      
-    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_AUTOQC;</command>
-    <jobname><cyclestr>&RUN;_autoqc_job_@Y@m@d@H@M</cyclestr></jobname>
-    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_autoqc_@Y@m@d@H.log</cyclestr></join>
-      
-    &ENVARS_AUTOQC;
-    
-    <dependency>
-          <taskdep task="&RUN;_gsianl_task"/>
-    </dependency>
-      
   </task>
 
   <task name="&RUN;_postsnd" cycledefs="hourly" maxtries="&maxtries;">
@@ -1315,29 +1337,6 @@
       </and>
     </dependency>
   </task>
-
-  <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
-
-    &ENVARS;
-    &UPDATEVARS_RESOURCES;
-    &UPDATEVARS_RESERVATION;
-    <envar>
-       <name>rundir_task</name>
-       <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
-    </envar>
-
-    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_UPDATEVARS;</command>
-    <jobname><cyclestr>&RUN;_updatevars_job_@Y@m@d@H@M</cyclestr></jobname>
-    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_updatevars_@Y@m@d@H.log</cyclestr></join>
-
-    &ENVARS_UPDATEVARS;
-
-    <dependency>
-          <taskdep task="&RUN;_gsianl_task"/>
-    </dependency>
-
-  </task>
-
 
   <task name="&RUN;_post_task" cycledefs="hourly" maxtries="&maxtries;">
 

--- a/workflow/rtma3d_pbspro_conus.xml
+++ b/workflow/rtma3d_pbspro_conus.xml
@@ -1244,6 +1244,28 @@
      </dependency>
   </task>
 
+  <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
+
+    &ENVARS;
+    &UPDATEVARS_RESOURCES;
+    &UPDATEVARS_RESERVATION;
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
+    </envar>
+
+    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_UPDATEVARS;</command>
+    <jobname><cyclestr>&RUN;_updatevars_job_@Y@m@d@H@M</cyclestr></jobname>
+    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_updatevars_@Y@m@d@H.log</cyclestr></join>
+
+    &ENVARS_UPDATEVARS;
+
+    <dependency>
+          <taskdep task="&RUN;_gsianl_task"/>
+    </dependency>
+
+  </task>
+
   <task name="&RUN;_ncdiag_task" cycledefs="hourly" maxtries="&maxtries;">
        
     &ENVARS;
@@ -1304,6 +1326,29 @@
     </dependency>
    </task>
 
+  <task name="&RUN;_autoqc_task" cycledefs="hourly" maxtries="&maxtries;">
+
+    &ENVARS;
+    &AUTOQC_RESOURCES;
+    &AUTOQC_RESERVATION;
+
+    <envar>
+       <name>rundir_task</name>
+       <value><cyclestr>&DATA_AUTOQC;</cyclestr></value>
+    </envar>
+
+    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_AUTOQC;</command>
+    <jobname><cyclestr>&RUN;_autoqc_job_@Y@m@d@H@M</cyclestr></jobname>
+    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_autoqc_@Y@m@d@H.log</cyclestr></join>
+
+    &ENVARS_AUTOQC;
+
+    <dependency>
+          <taskdep task="&RUN;_gsianl_task"/>
+    </dependency>
+
+  </task>
+
     <task name="&RUN;_wrfbufr" cycledefs="hourly" maxtries="&maxtries;">
     &ENVARS;
     <envar>
@@ -1318,32 +1363,9 @@
     <jobname>&NET;_wrfbufr</jobname>
     <join><cyclestr>&LOG_DIR;/&RUN;_wrfbufr_@Y@m@d@H@M.log</cyclestr></join>
     <dependency>
-      <taskdep task="&RUN;_gsianl_task"/>
+      <taskdep task="&RUN;_updatevars_task"/>
     </dependency>
 
-  </task>
-
-  <task name="&RUN;_autoqc_task" cycledefs="hourly" maxtries="&maxtries;">
-   
-    &ENVARS;
-    &AUTOQC_RESOURCES;  
-    &AUTOQC_RESERVATION;
-      
-    <envar>
-       <name>rundir_task</name>
-       <value><cyclestr>&DATA_AUTOQC;</cyclestr></value>
-    </envar>
-      
-    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_AUTOQC;</command>
-    <jobname><cyclestr>&RUN;_autoqc_job_@Y@m@d@H@M</cyclestr></jobname>
-    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_autoqc_@Y@m@d@H.log</cyclestr></join>
-      
-    &ENVARS_AUTOQC;
-    
-    <dependency>
-          <taskdep task="&RUN;_gsianl_task"/>
-    </dependency>
-      
   </task>
 
   <task name="&RUN;_postsnd" cycledefs="hourly" maxtries="&maxtries;">
@@ -1366,29 +1388,6 @@
       </and>
     </dependency>
   </task>
-
-  <task name="&RUN;_updatevars_task" cycledefs="hourly" maxtries="&maxtries;">
-
-    &ENVARS;
-    &UPDATEVARS_RESOURCES;
-    &UPDATEVARS_RESERVATION;
-    <envar>
-       <name>rundir_task</name>
-       <value><cyclestr>&DATA_WRFPRD;</cyclestr></value>
-    </envar>
-
-    <command>&WORKFLOW_DIR;/launch.ksh &JJOB_UPDATEVARS;</command>
-    <jobname><cyclestr>&RUN;_updatevars_job_@Y@m@d@H@M</cyclestr></jobname>
-    <join><cyclestr>&LOG_SCHDLR;/&RUN;_&envir;_updatevars_@Y@m@d@H.log</cyclestr></join>
-
-    &ENVARS_UPDATEVARS;
-
-    <dependency>
-          <taskdep task="&RUN;_gsianl_task"/>
-    </dependency>
-
-  </task>
-
 
   <task name="&RUN;_post_task" cycledefs="hourly" maxtries="&maxtries;">
 


### PR DESCRIPTION
The creation of the sharedprd directory in PR #81 created issues for the wrfbufr and subsequent postsnd tasks. The result is that the BUFR sounding files were not being generated, and this was traced back to the cycle in which this PR was merged into the parallel running on the production machine (20251021/16Z). The wrfbufr job is looking for the wrf_inout.nc file in the COM gsiprd.tHHz directory, and this file is no longer copied to the COM directory until after the completion of the updatevars task. The fix for this issue is to update the task dependency for the wrfbufr task from GSI to updatevars, and this was tested overnight in the 3DRTMA parallel running on the development machine. The findings are that the revised dependencies should have no impact on the overall cycle run time, as the sounding jobs still complete before the final task (prdgen).